### PR TITLE
Require numcodecs 0.5.3 and drop nose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
-nosetests.xml
 coverage.xml
 *,cover
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,8 +48,8 @@ To work with Zarr source code in development, install from GitHub::
 
 To verify that Zarr has been fully installed, run the test suite::
 
-    $ pip install nose
-    $ python -m nose -v zarr
+    $ pip install pytest
+    $ python -m pytest -v --pyargs zarr
 
 Contents
 --------

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -178,8 +178,8 @@ print some diagnostics, e.g.::
                        : blocksize=0)
     Store type         : builtins.dict
     No. bytes          : 400000000 (381.5M)
-    No. bytes stored   : 3702484 (3.5M)
-    Storage ratio      : 108.0
+    No. bytes stored   : 3242241 (3.1M)
+    Storage ratio      : 123.4
     Chunks initialized : 100/100
 
 If you don't specify a compressor, by default Zarr uses the Blosc
@@ -270,8 +270,8 @@ Here is an example using a delta filter with the Blosc compressor::
     Compressor         : Blosc(cname='zstd', clevel=1, shuffle=SHUFFLE, blocksize=0)
     Store type         : builtins.dict
     No. bytes          : 400000000 (381.5M)
-    No. bytes stored   : 328085 (320.4K)
-    Storage ratio      : 1219.2
+    No. bytes stored   : 648605 (633.4K)
+    Storage ratio      : 616.7
     Chunks initialized : 100/100
 
 For more information about available filter codecs, see the `Numcodecs
@@ -394,8 +394,8 @@ property. E.g.::
     Compressor         : Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0)
     Store type         : zarr.storage.DictStore
     No. bytes          : 8000000 (7.6M)
-    No. bytes stored   : 34840 (34.0K)
-    Storage ratio      : 229.6
+    No. bytes stored   : 33460 (32.7K)
+    Storage ratio      : 239.1
     Chunks initialized : 10/10
 
     >>> baz.info
@@ -1143,8 +1143,8 @@ ratios, depending on the correlation structure within the data. E.g.::
     Compressor         : Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0)
     Store type         : builtins.dict
     No. bytes          : 400000000 (381.5M)
-    No. bytes stored   : 15857834 (15.1M)
-    Storage ratio      : 25.2
+    No. bytes stored   : 10502688 (10.0M)
+    Storage ratio      : 38.1
     Chunks initialized : 100/100
     >>> f = zarr.array(a, chunks=(1000, 1000), order='F')
     >>> f.info
@@ -1157,8 +1157,8 @@ ratios, depending on the correlation structure within the data. E.g.::
     Compressor         : Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0)
     Store type         : builtins.dict
     No. bytes          : 400000000 (381.5M)
-    No. bytes stored   : 7233241 (6.9M)
-    Storage ratio      : 55.3
+    No. bytes stored   : 5530511 (5.3M)
+    Storage ratio      : 72.3
     Chunks initialized : 100/100
 
 In the above example, Fortran order gives a better compression ratio. This is an

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,7 +15,6 @@ idna==2.6
 mccabe==0.6.1
 monotonic==1.3
 msgpack-python==0.4.8
-nose==1.3.7
 numcodecs==0.5.3
 numpy==1.13.3
 packaging==16.8

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -16,7 +16,7 @@ mccabe==0.6.1
 monotonic==1.3
 msgpack-python==0.4.8
 nose==1.3.7
-numcodecs==0.5.2
+numcodecs==0.5.3
 numpy==1.13.3
 packaging==16.8
 pkginfo==1.4.1

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'asciitree',
         'numpy>=1.7',
         'fasteners',
-        'numcodecs>=0.5.2',
+        'numcodecs>=0.5.3',
     ],
     package_dir={'': '.'},
     packages=['zarr', 'zarr.tests'],

--- a/windows_conda_dev.txt
+++ b/windows_conda_dev.txt
@@ -4,7 +4,6 @@ fasteners
 flake8
 monotonic
 msgpack-python
-nose
 numcodecs
 numpy
 setuptools_scm


### PR DESCRIPTION
Bumps the `numcodecs` requirement to `0.5.3` as this version uses `pytest` only (without `nose`). As `zarr` uses some testing utilities from `numcodecs`, the version bump is needed to remove the indirect dependency on `nose`. With this requirement change, drop usage of `nose` throughout `zarr`. Also update the testing instructions to use `pytest` (instead of `nose`).