### PR TITLE
Use `os.renames` in `DirectoryStore`'s `rename`

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -841,10 +841,7 @@ class DirectoryStore(MutableMapping):
         src_path = os.path.join(dir_path, store_src_path)
         dst_path = os.path.join(dir_path, store_dst_path)
 
-        dst_dir = os.path.dirname(dst_path)
-        if not os.path.exists(dst_dir):
-            os.makedirs(dst_dir)
-        os.rename(src_path, dst_path)
+        os.renames(src_path, dst_path)
 
     def rmdir(self, path=None):
         store_path = normalize_storage_path(path)


### PR DESCRIPTION
Instead of using `os.rename` and creating missing directories before when renaming content in a `DirectoryStore`, just use `os.rename` to handle this move for us. This will automatically create missing directories for us in the destination path so we don't have to. Also it prunes away any empty directories in the old path, which we were not doing before. IOW this fixes a bug as well.