### PR TITLE
fix pickle tests: avoid multiple simultaneous active writers

### DIFF
--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -659,8 +659,16 @@ class TestArray(unittest.TestCase):
         z = self.create_array(shape=1000, chunks=100, dtype=int, cache_metadata=False,
                               cache_attrs=False)
         z[:] = np.random.randint(0, 1000, 1000)
-        z2 = pickle.loads(pickle.dumps(z))
-        assert z.shape == z2.shape
+        pickled = pickle.dumps(z)
+
+        shape = z.shape
+        array = z[:]
+
+        if hasattr(z.store, 'close'):
+            z.store.close()
+
+        z2 = pickle.loads(pickled)
+        assert shape == z2.shape
         assert z.chunks == z2.chunks
         assert z.dtype == z2.dtype
         if z.compressor:
@@ -668,7 +676,7 @@ class TestArray(unittest.TestCase):
         assert z.fill_value == z2.fill_value
         assert z._cache_metadata == z2._cache_metadata
         assert z.attrs.cache == z2.attrs.cache
-        assert_array_equal(z[:], z2[:])
+        assert_array_equal(array, z2[:])
 
     def test_np_ufuncs(self):
         z = self.create_array(shape=(100, 100), chunks=(10, 10))

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -819,6 +819,9 @@ class TestGroup(unittest.TestCase):
         with pytest.raises(ValueError):
             g1['foo/../bar']
 
+    def maybe_close(self, store):
+        pass
+
     def test_pickle(self):
         # setup
         g = self.create_group()
@@ -829,14 +832,23 @@ class TestGroup(unittest.TestCase):
         if hasattr(g.store, 'flush'):
             g.store.flush()
 
+        pickled = pickle.dumps(g)
+
+        elems = list(g)
+        foo = g['foo']
+        bar = g['foo/bar']
+
+        self.maybe_close(g.store)
+
         # pickle round trip
-        g2 = pickle.loads(pickle.dumps(g))
+        g2 = pickle.loads(pickled)
+
         assert g.path == g2.path
         assert g.name == g2.name
-        assert len(g) == len(g2)
-        assert list(g) == list(g2)
-        assert g['foo'] == g2['foo']
-        assert g['foo/bar'] == g2['foo/bar']
+        assert 1 == len(g2)
+        assert elems == list(g2)
+        assert foo == g2['foo']
+        assert bar == g2['foo/bar']
 
 
 class TestGroupWithDictStore(TestGroup):
@@ -877,6 +889,9 @@ class TestGroupWithZipStore(TestGroup):
 
 
 class TestGroupWithDBMStore(TestGroup):
+
+    def maybe_close(self, store):
+        store.close()
 
     @staticmethod
     def create_store():

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -131,9 +131,12 @@ class StoreTests(object):
         store = self.create_store()
         store['foo'] = b'bar'
         store['baz'] = b'quux'
-        store2 = pickle.loads(pickle.dumps(store))
-        assert len(store) == len(store2)
-        assert sorted(store.keys()) == sorted(store2.keys())
+        pickled = pickle.dumps(store)
+        if hasattr(store, 'close'):
+            store.close()
+        store2 = pickle.loads(pickled)
+        assert 2 == len(store2)
+        assert ['baz', 'foo'] == sorted(store2.keys())
         assert b'bar' == store2['foo']
         assert b'quux' == store2['baz']
 


### PR DESCRIPTION
Several `test_pickle` cases fail for me on OSX (10.13.5) and in a CentOS (7.5) VM; [here's a full example](https://gist.github.com/ryan-williams/b4093db6a978c1c9066da5c15efd9d9d).

A minimal repro:

```python
import tempfile
from zarr.storage import DBMStore
import pickle
path = tempfile.mktemp()
store = DBMStore(path, flag='n')
store['foo'] = b'bar'
pickled = pickle.dumps(store)
store2 = pickle.loads(pickled)
```

Running this gives:

```
Traceback (most recent call last):
  File "test.py", line 8, in <module>
    store2 = pickle.loads(pickled)
  File "/Users/ryan/c/hdf5-experiments/zarr/zarr/storage.py", line 1449, in __setstate__
    write_lock=write_lock, **open_kws)
  File "/Users/ryan/c/hdf5-experiments/zarr/zarr/storage.py", line 1425, in __init__
    self.db = open(path, flag, mode, **open_kwargs)
  File "/Users/ryan/.pyenv/versions/3.6.5/lib/python3.6/dbm/__init__.py", line 94, in open
    return mod.open(file, flag, mode)
_gdbm.error: [Errno 35] Resource temporarily unavailable
```

It seems to be related to having multiple file-descriptors open with "write" capabilities to a given path.

This fixes them for me locally; I don't know why they don't appear on Travis.
