### PR TITLE
avoid race condition during chunk write

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -19,22 +19,28 @@ Enhancements
 * Support has been added for structured arrays with sub-array shape and/or nested fields. By
   :user:`Tarik Onalan <onalant>`, :issue:`111`, :issue:`296`.
 
-Maintenance
-~~~~~~~~~~~
+Bug fixes
+~~~~~~~~~
+
+* The implementation of the :class:`zarr.storage.DirectoryStore` class has been modified to 
+  ensure that writes are atomic and there are no race conditions where a chunk might appear 
+  transiently missing during a write operation. By :user:`sbalmer <sbalmer>`, :issue:`327`, 
+  :issue:`263`.
 
 * The required version of the `numcodecs <http://numcodecs.rtfd.io>`_ package has been upgraded 
   to 0.6.2, which has enabled some code simplification and fixes a failing test involving
   msgpack encoding. By :user:`John Kirkham <jakirkham>`, :issue:`352`, :issue:`355`, 
   :issue:`324`.
 
-* CI and test environments have been upgraded to include Python 3.7, drop Python 3.4, and
-  upgrade all pinned package requirements. :issue:`308`.
-
 * Failing tests related to pickling/unpickling have been fixed. By :user:`Ryan Williams <ryan-williams>`,
   :issue:`273`, :issue:`308`.
 
-Acknowledgments
-~~~~~~~~~~~~~~~
+Maintenance
+~~~~~~~~~~~
+
+* CI and test environments have been upgraded to include Python 3.7, drop Python 3.4, and
+  upgrade all pinned package requirements. :issue:`308`.
+
 
 .. _release_2.2.0:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ fasteners
 numcodecs
 numpy
 pytest
+pyosreplace; python_version < '3.3' and sys.platform == 'win32'

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 asciitree==0.3.3
 fasteners==0.14.1
 numcodecs==0.5.5
+pyosreplace==0.1; python_version < '3.3' and sys.platform == 'win32'

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
 from setuptools import setup
+import sys
 
 
 DESCRIPTION = 'An implementation of chunked, compressed, ' \
@@ -8,6 +9,16 @@ DESCRIPTION = 'An implementation of chunked, compressed, ' \
 
 with open('README.rst') as f:
     LONG_DESCRIPTION = f.read()
+
+dependencies = [
+    'asciitree',
+    'numpy>=1.7',
+    'fasteners',
+    'numcodecs>=0.5.3',
+]
+
+if sys.version_info < (3, 3) and sys.platform == "win32":
+    dependencies.append('pyosreplace')
 
 setup(
     name='zarr',
@@ -22,13 +33,7 @@ setup(
         'setuptools>18.0',
         'setuptools-scm>1.5.4'
     ],
-    install_requires=[
-        'asciitree',
-        'numpy>=1.7',
-        'fasteners',
-        'numcodecs>=0.5.3',
-        "pyosreplace : python_version < '3.3' and sys.platform == 'win32'",
-    ],
+    install_requires=dependencies,
     package_dir={'': '.'},
     packages=['zarr', 'zarr.tests'],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'numpy>=1.7',
         'fasteners',
         'numcodecs>=0.5.3',
+        "pyosreplace : python_version < '3.3' and sys.platform == 'win32'",
     ],
     package_dir={'': '.'},
     packages=['zarr', 'zarr.tests'],

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -772,9 +772,18 @@ class DirectoryStore(MutableMapping):
                 f.write(value)
 
             # move temporary file into place
-            if os.path.exists(file_path):
-                os.remove(file_path)
-            os.rename(temp_path, file_path)
+            if hasattr(os, 'replace'):
+                # Python >= 3.3 has replace() which can replace existing
+                # files on all platforms.
+                os.replace(temp_path, file_path)
+            else:
+                # In Python < 3.3 use rename().
+                if os.name == 'nt' and os.path.exists(file_path):
+                    # On windows, rename() can't overwrite files. So
+                    # the file is removed first.
+                    os.remove(file_path)
+
+                os.rename(temp_path, file_path)
 
         finally:
             # clean up if temp file still exists for whatever reason

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -54,23 +54,14 @@ except ImportError:  # pragma: no cover
     from zarr.codecs import Zlib
     default_compressor = Zlib()
 
-# Find the best function for FS replace.
-# Preferably atomic.
-if hasattr(os, 'replace'):
-    # Python >= 3.3 has replace() which can replace existing
-    # files on all platforms.
-    replace = os.replace
+# Find which function to use for atomic replace
+if sys.version_info >= (3, 3):
+    from os import replace
+elif sys.platform == "win32":
+    from osreplace import replace
 else:
-    # In Python < 3.3 use rename().
-    if os.name == 'nt':
-        def replace(old, new):
-            if os.path.exists(new):
-                # On windows, rename() can't overwrite files. So
-                # the file is removed first.
-                os.remove(new)
-            os.rename(old, new)
-    else:
-        replace = os.rename
+    # POSIX rename() is always atomic
+    from os import rename as replace
 
 
 def _path_to_prefix(path):

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -57,9 +57,9 @@ except ImportError:  # pragma: no cover
 # Find which function to use for atomic replace
 if sys.version_info >= (3, 3):
     from os import replace
-elif sys.platform == "win32":
+elif sys.platform == "win32":  # pragma: no cover
     from osreplace import replace
-else:
+else:  # pragma: no cover
     # POSIX rename() is always atomic
     from os import rename as replace
 


### PR DESCRIPTION
When the chunk file is first removed before the new version
is moved into place, racing reads may encounter a missing chunk.

Using rename() or replace() without remove() avoids the issue
on Posix-Systems as the methods are atomic. The fallback of
remove() -> rename() is included for Windows pre Python 3.3.

Fixes #263

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
