### PR TITLE
bump requests version in dev environment

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -44,7 +44,7 @@ pytest==3.9.1
 pytest-cov==2.6.0
 python-dateutil==2.7.3
 readme-renderer==22.0
-requests==2.19.1
+requests==2.20.0
 requests-toolbelt==0.8.0
 s3fs==0.1.6
 s3transfer==0.1.13


### PR DESCRIPTION
This simply bumps the version of the requests library in the dev environment. I'm doing this because GitHub keeps sending me emails about a known security vulnerability in requests<= 2.19.1. This satisfy that issue.

![image](https://user-images.githubusercontent.com/2443309/48449910-f0ecf700-e758-11e8-8bd0-b57ec247498c.png)

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
