### PR TITLE
Fix coverage for consolidated metadata store

### DIFF
--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -19,12 +19,13 @@ from zarr.storage import (init_array, array_meta_key, attrs_key, DictStore,
                           DirectoryStore, ZipStore, init_group, group_meta_key,
                           getsize, migrate_1to2, TempStore, atexit_rmtree,
                           NestedDirectoryStore, default_compressor, DBMStore,
-                          LMDBStore, atexit_rmglob, LRUStoreCache)
+                          LMDBStore, atexit_rmglob, LRUStoreCache,
+                          ConsolidatedMetadataStore)
 from zarr.meta import (decode_array_metadata, encode_array_metadata, ZARR_FORMAT,
                        decode_group_metadata, encode_group_metadata)
 from zarr.compat import PY2
 from zarr.codecs import Zlib, Blosc, BZ2
-from zarr.errors import PermissionError
+from zarr.errors import PermissionError, MetadataError
 from zarr.hierarchy import group
 from zarr.tests.util import CountingDict
 
@@ -1251,3 +1252,16 @@ def test_format_compatibility():
             else:
                 assert compressor.codec_id == z.compressor.codec_id
                 assert compressor.get_config() == z.compressor.get_config()
+
+
+class TestConsolidatedMetadataStore(unittest.TestCase):
+
+    def test_bad_format(self):
+        store = dict()
+        metadata = json.dumps({
+            # bad format version
+            'zarr_consolidated_format': 0,
+        })
+        store['.zmetadata'] = metadata
+        with pytest.raises(MetadataError):
+            ConsolidatedMetadataStore(store)


### PR DESCRIPTION
Resolves #331.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
