### PR TITLE
Configure flake8's line length as 100

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ commands =
     # run doctests in the tutorial and spec
     py37: python -m doctest -o NORMALIZE_WHITESPACE -o ELLIPSIS docs/tutorial.rst docs/spec/v2.rst
     # pep8 checks
-    py37: flake8 --max-line-length=100 zarr
+    py37: flake8 zarr
     # print environment for debugging
     pip freeze
 deps =
@@ -49,3 +49,6 @@ deps =
     -rrequirements_rtfd.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
+
+[flake8]
+max-line-length = 100


### PR DESCRIPTION
Same as PR ( https://github.com/zarr-developers/numcodecs/pull/124 ) for Zarr.

This allows users to run `flake8 zarr` and pick up the desired configuration by default.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
