### PR TITLE
Bump Numcodecs requirement to 0.6.1

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -176,7 +176,7 @@ print some diagnostics, e.g.::
     Read-only          : False
     Compressor         : Blosc(cname='zstd', clevel=3, shuffle=BITSHUFFLE,
                        : blocksize=0)
-    Store type         : builtins.dict
+    Store type         : zarr.storage.DictStore
     No. bytes          : 400000000 (381.5M)
     No. bytes stored   : 3242241 (3.1M)
     Storage ratio      : 123.4
@@ -268,7 +268,7 @@ Here is an example using a delta filter with the Blosc compressor::
     Read-only          : False
     Filter [0]         : Delta(dtype='<i4')
     Compressor         : Blosc(cname='zstd', clevel=1, shuffle=SHUFFLE, blocksize=0)
-    Store type         : builtins.dict
+    Store type         : zarr.storage.DictStore
     No. bytes          : 400000000 (381.5M)
     No. bytes stored   : 648605 (633.4K)
     Storage ratio      : 616.7
@@ -1181,7 +1181,7 @@ ratios, depending on the correlation structure within the data. E.g.::
     Order              : C
     Read-only          : False
     Compressor         : Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0)
-    Store type         : builtins.dict
+    Store type         : zarr.storage.DictStore
     No. bytes          : 400000000 (381.5M)
     No. bytes stored   : 6696010 (6.4M)
     Storage ratio      : 59.7
@@ -1195,7 +1195,7 @@ ratios, depending on the correlation structure within the data. E.g.::
     Order              : F
     Read-only          : False
     Compressor         : Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0)
-    Store type         : builtins.dict
+    Store type         : zarr.storage.DictStore
     No. bytes          : 400000000 (381.5M)
     No. bytes stored   : 4684636 (4.5M)
     Storage ratio      : 85.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,3 @@
 asciitree==0.3.3
 fasteners==0.14.1
-numcodecs==0.5.5
+numcodecs==0.6.1

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'asciitree',
         'numpy>=1.7',
         'fasteners',
-        'numcodecs>=0.5.3',
+        'numcodecs>=0.6.1',
     ],
     package_dir={'': '.'},
     packages=['zarr', 'zarr.tests'],

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1749,11 +1749,7 @@ class Array(object):
         if self._dtype == object:
             # special case object dtype, because incorrect handling can lead to
             # segfaults and other bad things happening
-            if chunk.dtype == object:
-                # chunk is already of correct dtype, good to carry on
-                # flatten just to be sure we can reshape later
-                chunk = chunk.reshape(-1, order='A')
-            else:
+            if chunk.dtype != object:
                 # If we end up here, someone must have hacked around with the filters.
                 # We cannot deal with object arrays unless there is an object
                 # codec in the filter chain, i.e., a filter that converts from object
@@ -1761,9 +1757,10 @@ class Array(object):
                 # array during decoding.
                 raise RuntimeError('cannot read object array without object codec')
         else:
-            chunk = chunk.reshape(-1, order='A').view(self._dtype)
+            chunk = chunk.view(self._dtype)
 
         # ensure correct chunk shape
+        chunk = chunk.reshape(-1, order='A')
         chunk = chunk.reshape(self._chunks, order=self._order)
 
         return chunk

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1746,18 +1746,17 @@ class Array(object):
 
         # view as numpy array with correct dtype
         chunk = ensure_ndarray(chunk)
-        if self._dtype == object:
-            # special case object dtype, because incorrect handling can lead to
-            # segfaults and other bad things happening
-            if chunk.dtype != object:
-                # If we end up here, someone must have hacked around with the filters.
-                # We cannot deal with object arrays unless there is an object
-                # codec in the filter chain, i.e., a filter that converts from object
-                # array to something else during encoding, and converts back to object
-                # array during decoding.
-                raise RuntimeError('cannot read object array without object codec')
-        else:
+        # special case object dtype, because incorrect handling can lead to
+        # segfaults and other bad things happening
+        if self._dtype != object:
             chunk = chunk.view(self._dtype)
+        elif chunk.dtype != object:
+            # If we end up here, someone must have hacked around with the filters.
+            # We cannot deal with object arrays unless there is an object
+            # codec in the filter chain, i.e., a filter that converts from object
+            # array to something else during encoding, and converts back to object
+            # array during decoding.
+            raise RuntimeError('cannot read object array without object codec')
 
         # ensure correct chunk shape
         chunk = chunk.reshape(-1, order='A')

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -8,6 +8,7 @@ import re
 
 
 import numpy as np
+from numcodecs.compat import ensure_contiguous_ndarray
 
 
 from zarr.util import (is_total_slice, human_readable_size, normalize_resize_args,
@@ -1743,18 +1744,25 @@ class Array(object):
             for f in self._filters[::-1]:
                 chunk = f.decode(chunk)
 
-        # view as correct dtype
+        # view as numpy array with correct dtype
         if self._dtype == object:
-            if isinstance(chunk, np.ndarray):
-                chunk = chunk.astype(self._dtype)
+            # special case object dtype, because incorrect handling can lead to
+            # segfaults and other bad things happening
+            if isinstance(chunk, np.ndarray) and chunk.dtype == object:
+                # chunk is already of correct dtype, good to carry on
+                # flatten just to be sure we can reshape later
+                chunk = chunk.reshape(-1, order='A')
             else:
+                # If we end up here, someone must have hacked around with the filters.
+                # We cannot deal with object arrays unless there is an object
+                # codec in the filter chain, i.e., a filter that converts from object
+                # array to something else during encoding, and converts back to object
+                # array during decoding.
                 raise RuntimeError('cannot read object array without object codec')
-        elif isinstance(chunk, np.ndarray):
-            chunk = chunk.view(self._dtype)
         else:
-            chunk = np.frombuffer(chunk, dtype=self._dtype)
+            chunk = ensure_contiguous_ndarray(chunk).view(self._dtype)
 
-        # reshape
+        # ensure correct chunk shape
         chunk = chunk.reshape(self._chunks, order=self._order)
 
         return chunk

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1811,10 +1811,10 @@ class Array(object):
         Order              : C
         Read-only          : False
         Compressor         : Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0)
-        Store type         : builtins.dict
+        Store type         : zarr.storage.DictStore
         No. bytes          : 4000000 (3.8M)
-        No. bytes stored   : ...
-        Storage ratio      : ...
+        No. bytes stored   : 320
+        Storage ratio      : 12500.0
         Chunks initialized : 0/10
 
         """

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -8,7 +8,7 @@ import re
 
 
 import numpy as np
-from numcodecs.compat import ensure_contiguous_ndarray
+from numcodecs.compat import ensure_ndarray, ensure_contiguous_ndarray
 
 
 from zarr.util import (is_total_slice, human_readable_size, normalize_resize_args,
@@ -1745,10 +1745,11 @@ class Array(object):
                 chunk = f.decode(chunk)
 
         # view as numpy array with correct dtype
+        chunk = ensure_ndarray(chunk)
         if self._dtype == object:
             # special case object dtype, because incorrect handling can lead to
             # segfaults and other bad things happening
-            if isinstance(chunk, np.ndarray) and chunk.dtype == object:
+            if chunk.dtype == object:
                 # chunk is already of correct dtype, good to carry on
                 # flatten just to be sure we can reshape later
                 chunk = chunk.reshape(-1, order='A')

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -8,7 +8,7 @@ import re
 
 
 import numpy as np
-from numcodecs.compat import ensure_ndarray, ensure_contiguous_ndarray
+from numcodecs.compat import ensure_ndarray
 
 
 from zarr.util import (is_total_slice, human_readable_size, normalize_resize_args,
@@ -1761,7 +1761,7 @@ class Array(object):
                 # array during decoding.
                 raise RuntimeError('cannot read object array without object codec')
         else:
-            chunk = ensure_contiguous_ndarray(chunk).view(self._dtype)
+            chunk = chunk.reshape(-1, order='A').view(self._dtype)
 
         # ensure correct chunk shape
         chunk = chunk.reshape(self._chunks, order=self._order)

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -7,7 +7,7 @@ import numpy as np
 
 
 from zarr.core import Array
-from zarr.storage import (DirectoryStore, init_array, contains_array, contains_group,
+from zarr.storage import (DictStore, DirectoryStore, init_array, contains_array, contains_group,
                           default_compressor, normalize_storage_path, ZipStore)
 from numcodecs.registry import codec_registry
 from zarr.errors import err_contains_array, err_contains_group, err_array_not_found
@@ -125,7 +125,7 @@ def create(shape, chunks=True, dtype=None, compressor='default',
     return z
 
 
-def normalize_store_arg(store, clobber=False, default=dict):
+def normalize_store_arg(store, clobber=False, default=DictStore):
     if store is None:
         return default()
     elif isinstance(store, str):

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -5,9 +5,10 @@ import base64
 
 
 import numpy as np
+from numcodecs.compat import ensure_bytes
 
 
-from zarr.compat import PY2, binary_type, Mapping
+from zarr.compat import PY2, Mapping
 from zarr.errors import MetadataError
 
 
@@ -15,14 +16,9 @@ ZARR_FORMAT = 2
 
 
 def ensure_str(s):
-    if PY2:  # pragma: py3 no cover
-        # noinspection PyUnresolvedReferences
-        if isinstance(s, buffer):  # noqa
-            s = str(s)
-    else:  # pragma: py2 no cover
-        if isinstance(s, memoryview):
-            s = s.tobytes()
-        if isinstance(s, binary_type):
+    if not isinstance(s, str):
+        s = ensure_bytes(s)
+        if not PY2:  # pragma: py2 no cover
             s = s.decode('ascii')
     return s
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -445,23 +445,6 @@ def _init_group_metadata(store, overwrite=False, path=None, chunk_store=None):
     store[key] = encode_group_metadata(meta)
 
 
-def ensure_bytes(s):
-    if isinstance(s, binary_type):
-        return s
-    if isinstance(s, np.ndarray):
-        if PY2:  # pragma: py3 no cover
-            # noinspection PyArgumentList
-            return s.tostring(order='A')
-        else:  # pragma: py2 no cover
-            # noinspection PyArgumentList
-            return s.tobytes(order='A')
-    if hasattr(s, 'tobytes'):
-        return s.tobytes()
-    if PY2 and hasattr(s, 'tostring'):  # pragma: py3 no cover
-        return s.tostring()
-    return memoryview(s).tobytes()
-
-
 def _dict_store_keys(d, prefix='', cls=dict):
     for k in d.keys():
         v = d[k]

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -634,17 +634,11 @@ class DictStore(MutableMapping):
             size = 0
             for v in value.values():
                 if not isinstance(v, self.cls):
-                    try:
-                        size += buffer_size(v)
-                    except TypeError:
-                        return -1
+                    size += buffer_size(v)
             return size
 
         else:
-            try:
-                return buffer_size(value)
-            except TypeError:
-                return -1
+            return buffer_size(value)
 
     def clear(self):
         with self.write_mutex:

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -719,6 +719,8 @@ class DirectoryStore(MutableMapping):
 
         # coerce to flat, contiguous array (ideally without copying)
         value = ensure_ndarray(value).reshape(-1, order='A')
+        if value.dtype.kind in 'mM':
+            value = value.view('i8')
 
         # destination path for key
         file_path = os.path.join(self.path, key)
@@ -1168,6 +1170,8 @@ class ZipStore(MutableMapping):
         if self.mode == 'r':
             err_read_only()
         value = ensure_ndarray(value).reshape(-1, order='A')
+        if value.dtype.kind in 'mM':
+            value = value.view('i8')
         with self.mutex:
             self.zf.writestr(key, value)
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -38,7 +38,7 @@ from zarr.util import (normalize_shape, normalize_chunks, normalize_order,
                        normalize_storage_path, buffer_size,
                        normalize_fill_value, nolock, normalize_dtype)
 from zarr.meta import encode_array_metadata, encode_group_metadata
-from zarr.compat import PY2, binary_type, OrderedDict_move_to_end
+from zarr.compat import PY2, OrderedDict_move_to_end
 from numcodecs.registry import codec_registry
 from numcodecs.compat import ensure_bytes
 from zarr.errors import (err_contains_group, err_contains_array, err_bad_compressor,

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -40,6 +40,7 @@ from zarr.util import (normalize_shape, normalize_chunks, normalize_order,
 from zarr.meta import encode_array_metadata, encode_group_metadata
 from zarr.compat import PY2, binary_type, OrderedDict_move_to_end
 from numcodecs.registry import codec_registry
+from numcodecs.compat import ensure_bytes
 from zarr.errors import (err_contains_group, err_contains_array, err_bad_compressor,
                          err_fspath_exists_notdir, err_read_only, MetadataError)
 
@@ -554,6 +555,8 @@ class DictStore(MutableMapping):
     def __setitem__(self, item, value):
         with self.write_mutex:
             parent, key = self._require_parent(item)
+            if not isinstance(value, self.cls):
+                value = ensure_bytes(value)
             parent[key] = value
 
     def __delitem__(self, item):

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -485,12 +485,11 @@ class DictStore(MutableMapping):
         >>> type(g.store)
         <class 'zarr.storage.DictStore'>
 
-    Note that the default class when creating an array is the built-in
-    :class:`dict` class, i.e.::
+    Also this is the default class when creating an array. E.g.::
 
         >>> z = zarr.zeros(100)
         >>> type(z.store)
-        <class 'dict'>
+        <class 'zarr.storage.DictStore'>
 
     Notes
     -----

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -37,7 +37,7 @@ from zarr.util import (normalize_shape, normalize_chunks, normalize_order,
 from zarr.meta import encode_array_metadata, encode_group_metadata
 from zarr.compat import PY2, OrderedDict_move_to_end
 from numcodecs.registry import codec_registry
-from numcodecs.compat import ensure_bytes, ensure_ndarray
+from numcodecs.compat import ensure_bytes, ensure_contiguous_ndarray
 from zarr.errors import (err_contains_group, err_contains_array, err_bad_compressor,
                          err_fspath_exists_notdir, err_read_only, MetadataError)
 
@@ -718,9 +718,7 @@ class DirectoryStore(MutableMapping):
     def __setitem__(self, key, value):
 
         # coerce to flat, contiguous array (ideally without copying)
-        value = ensure_ndarray(value).reshape(-1, order='A')
-        if value.dtype.kind in 'mM':
-            value = value.view('i8')
+        value = ensure_contiguous_ndarray(value)
 
         # destination path for key
         file_path = os.path.join(self.path, key)
@@ -1169,9 +1167,7 @@ class ZipStore(MutableMapping):
     def __setitem__(self, key, value):
         if self.mode == 'r':
             err_read_only()
-        value = ensure_ndarray(value).reshape(-1, order='A')
-        if value.dtype.kind in 'mM':
-            value = value.view('i8')
+        value = ensure_contiguous_ndarray(value)
         with self.mutex:
             self.zf.writestr(key, value)
 

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -982,7 +982,7 @@ class TestArray(unittest.TestCase):
         z[0] = 'foo'
         assert z[0] == 'foo'
         z[1] = b'bar'
-        assert z[1] == 'bar'  # msgpack gets this wrong
+        assert z[1] == b'bar'
         z[2] = 1
         assert z[2] == 1
         z[3] = [2, 4, 6, 'baz']

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -633,14 +633,6 @@ class TestDictStore(StoreTests, unittest.TestCase):
         store = self.create_store()
         setdel_hierarchy_checks(store)
 
-    def test_getsize_ext(self):
-        store = self.create_store()
-        store['a'] = list(range(10))
-        store['b/c'] = list(range(10))
-        assert -1 == store.getsize()
-        assert -1 == store.getsize('a')
-        assert -1 == store.getsize('b')
-
 
 class TestDirectoryStore(StoreTests, unittest.TestCase):
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1088,6 +1088,10 @@ def test_getsize():
     assert 7 == getsize(store)
     assert 5 == getsize(store, 'baz')
 
+    store = dict()
+    store['boo'] = None
+    assert -1 == getsize(store)
+
 
 def test_migrate_1to2():
     from zarr import meta_v1

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
-import operator
 from textwrap import TextWrapper, dedent
 import numbers
 import uuid
@@ -10,10 +9,11 @@ import inspect
 from asciitree import BoxStyle, LeftAligned
 from asciitree.traversal import Traversal
 import numpy as np
+from numcodecs.compat import ensure_ndarray
 from numcodecs.registry import codec_registry
 
 
-from zarr.compat import PY2, reduce, text_type, binary_type
+from zarr.compat import PY2, text_type, binary_type
 
 
 # codecs to use for object dtype convenience API
@@ -314,17 +314,7 @@ def normalize_storage_path(path):
 
 
 def buffer_size(v):
-    from array import array as _stdlib_array
-    if PY2 and isinstance(v, _stdlib_array):  # pragma: py3 no cover
-        # special case array.array because does not support buffer
-        # interface in PY2
-        return v.buffer_info()[1] * v.itemsize
-    else:  # pragma: py2 no cover
-        v = memoryview(v)
-        if v.shape:
-            return reduce(operator.mul, v.shape) * v.itemsize
-        else:
-            return v.itemsize
+    return ensure_ndarray(v).nbytes
 
 
 def info_text_report(items):


### PR DESCRIPTION
As there are some critical fixes in the latest Numcodecs, this bumps our lower bound to the latest version.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
