### PR TITLE
Ensure `DictStore` contains only `bytes`

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -35,6 +35,9 @@ Bug fixes
 * Failing tests related to pickling/unpickling have been fixed. By :user:`Ryan Williams <ryan-williams>`,
   :issue:`273`, :issue:`308`.
 
+* Ensure ``DictStore`` contains only ``bytes`` to facilitate comparisons and protect against writes.
+  By :user:`John Kirkham <jakirkham>`, :issue:`350`
+
 Maintenance
 ~~~~~~~~~~~
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -544,6 +544,8 @@ class DictStore(MutableMapping):
     def __setitem__(self, item, value):
         with self.write_mutex:
             parent, key = self._require_parent(item)
+            if not isinstance(value, self.cls):
+                value = ensure_bytes(value)
             parent[key] = value
 
     def __delitem__(self, item):

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -544,8 +544,7 @@ class DictStore(MutableMapping):
     def __setitem__(self, item, value):
         with self.write_mutex:
             parent, key = self._require_parent(item)
-            if not isinstance(value, self.cls):
-                value = ensure_bytes(value)
+            value = ensure_bytes(value)
             parent[key] = value
 
     def __delitem__(self, item):

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -644,17 +644,11 @@ class DictStore(MutableMapping):
             size = 0
             for v in value.values():
                 if not isinstance(v, self.cls):
-                    try:
-                        size += buffer_size(v)
-                    except TypeError:
-                        return -1
+                    size += buffer_size(v)
             return size
 
         else:
-            try:
-                return buffer_size(value)
-            except TypeError:
-                return -1
+            return buffer_size(value)
 
     def clear(self):
         with self.write_mutex:

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -639,6 +639,11 @@ class TestDictStore(StoreTests, unittest.TestCase):
     def create_store(self):
         return DictStore()
 
+    def test_store_contains_bytes(self):
+        store = self.create_store()
+        store['foo'] = np.array([97, 98, 99, 100, 101], dtype=np.uint8)
+        assert store['foo'] == b'abcde'
+
     def test_setdel(self):
         store = self.create_store()
         setdel_hierarchy_checks(store)

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -633,14 +633,6 @@ class TestDictStore(StoreTests, unittest.TestCase):
         store = self.create_store()
         setdel_hierarchy_checks(store)
 
-    def test_getsize_ext(self):
-        store = self.create_store()
-        store['a'] = list(range(10))
-        store['b/c'] = list(range(10))
-        assert -1 == store.getsize()
-        assert -1 == store.getsize('a')
-        assert -1 == store.getsize('b')
-
 
 class TestDirectoryStore(StoreTests, unittest.TestCase):
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1088,6 +1088,10 @@ def test_getsize():
     assert 7 == getsize(store)
     assert 5 == getsize(store, 'baz')
 
+    store = dict()
+    store['boo'] = None
+    assert -1 == getsize(store)
+
 
 def test_migrate_1to2():
     from zarr import meta_v1

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -63,6 +63,12 @@ class StoreTests(object):
                 # noinspection PyStatementEffect
                 del store['foo']
 
+    def test_set_invalid_content(self):
+        store = self.create_store()
+
+        with pytest.raises(TypeError):
+            store['baz'] = list(range(5))
+
     def test_clear(self):
         store = self.create_store()
         store['foo'] = b'bar'
@@ -585,6 +591,10 @@ class TestMappingStore(StoreTests, unittest.TestCase):
 
     def create_store(self):
         return dict()
+
+    def test_set_invalid_content(self):
+        # Generic mappings support non-buffer types
+        pass
 
 
 def setdel_hierarchy_checks(store):


### PR DESCRIPTION
Partially addresses issue ( https://github.com/zarr-developers/zarr/issues/348 ) and issue ( https://github.com/zarr-developers/zarr/issues/349 ).

As the spec notes stores values must be an "arbitrary sequence of bytes", this change ensures that values in `DictStore` meet that constraint. Of course nesting of `DictStore`s are still allowed per usual. However these really just map to a variety of keys, which is fine.

Since the `DictStore`'s values are just `bytes`, there shouldn't be any cases where the size of these values cannot be determined. So drop handling for unknown sizes in `buffer_size`. Also drop the associated test for `DictStore` as this cannot occur.

Add a test case for `getsize` with a non-conforming `dict`-based store where sizes are unknown to make sure that case is tested and handled appropriately.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
