### PR TITLE
Bump Numcodecs requirement to 0.6.2

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,3 @@
 asciitree==0.3.3
 fasteners==0.14.1
-numcodecs==0.5.5
+numcodecs==0.6.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,3 @@
 asciitree==0.3.3
 fasteners==0.14.1
-numcodecs==0.6.1
+numcodecs==0.6.2

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'asciitree',
         'numpy>=1.7',
         'fasteners',
-        'numcodecs>=0.5.3',
+        'numcodecs>=0.6.1',
     ],
     package_dir={'': '.'},
     packages=['zarr', 'zarr.tests'],

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'asciitree',
         'numpy>=1.7',
         'fasteners',
-        'numcodecs>=0.6.1',
+        'numcodecs>=0.6.2',
     ],
     package_dir={'': '.'},
     packages=['zarr', 'zarr.tests'],

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1749,11 +1749,7 @@ class Array(object):
         if self._dtype == object:
             # special case object dtype, because incorrect handling can lead to
             # segfaults and other bad things happening
-            if chunk.dtype == object:
-                # chunk is already of correct dtype, good to carry on
-                # flatten just to be sure we can reshape later
-                chunk = chunk.reshape(-1, order='A')
-            else:
+            if chunk.dtype != object:
                 # If we end up here, someone must have hacked around with the filters.
                 # We cannot deal with object arrays unless there is an object
                 # codec in the filter chain, i.e., a filter that converts from object
@@ -1761,9 +1757,10 @@ class Array(object):
                 # array during decoding.
                 raise RuntimeError('cannot read object array without object codec')
         else:
-            chunk = chunk.reshape(-1, order='A').view(self._dtype)
+            chunk = chunk.view(self._dtype)
 
         # ensure correct chunk shape
+        chunk = chunk.reshape(-1, order='A')
         chunk = chunk.reshape(self._chunks, order=self._order)
 
         return chunk

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1746,18 +1746,17 @@ class Array(object):
 
         # view as numpy array with correct dtype
         chunk = ensure_ndarray(chunk)
-        if self._dtype == object:
-            # special case object dtype, because incorrect handling can lead to
-            # segfaults and other bad things happening
-            if chunk.dtype != object:
-                # If we end up here, someone must have hacked around with the filters.
-                # We cannot deal with object arrays unless there is an object
-                # codec in the filter chain, i.e., a filter that converts from object
-                # array to something else during encoding, and converts back to object
-                # array during decoding.
-                raise RuntimeError('cannot read object array without object codec')
-        else:
+        # special case object dtype, because incorrect handling can lead to
+        # segfaults and other bad things happening
+        if self._dtype != object:
             chunk = chunk.view(self._dtype)
+        elif chunk.dtype != object:
+            # If we end up here, someone must have hacked around with the filters.
+            # We cannot deal with object arrays unless there is an object
+            # codec in the filter chain, i.e., a filter that converts from object
+            # array to something else during encoding, and converts back to object
+            # array during decoding.
+            raise RuntimeError('cannot read object array without object codec')
 
         # ensure correct chunk shape
         chunk = chunk.reshape(-1, order='A')

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -8,6 +8,7 @@ import re
 
 
 import numpy as np
+from numcodecs.compat import ensure_contiguous_ndarray
 
 
 from zarr.util import (is_total_slice, human_readable_size, normalize_resize_args,
@@ -1743,18 +1744,25 @@ class Array(object):
             for f in self._filters[::-1]:
                 chunk = f.decode(chunk)
 
-        # view as correct dtype
+        # view as numpy array with correct dtype
         if self._dtype == object:
-            if isinstance(chunk, np.ndarray):
-                chunk = chunk.astype(self._dtype)
+            # special case object dtype, because incorrect handling can lead to
+            # segfaults and other bad things happening
+            if isinstance(chunk, np.ndarray) and chunk.dtype == object:
+                # chunk is already of correct dtype, good to carry on
+                # flatten just to be sure we can reshape later
+                chunk = chunk.reshape(-1, order='A')
             else:
+                # If we end up here, someone must have hacked around with the filters.
+                # We cannot deal with object arrays unless there is an object
+                # codec in the filter chain, i.e., a filter that converts from object
+                # array to something else during encoding, and converts back to object
+                # array during decoding.
                 raise RuntimeError('cannot read object array without object codec')
-        elif isinstance(chunk, np.ndarray):
-            chunk = chunk.view(self._dtype)
         else:
-            chunk = np.frombuffer(chunk, dtype=self._dtype)
+            chunk = ensure_contiguous_ndarray(chunk).view(self._dtype)
 
-        # reshape
+        # ensure correct chunk shape
         chunk = chunk.reshape(self._chunks, order=self._order)
 
         return chunk

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -8,7 +8,7 @@ import re
 
 
 import numpy as np
-from numcodecs.compat import ensure_contiguous_ndarray
+from numcodecs.compat import ensure_ndarray, ensure_contiguous_ndarray
 
 
 from zarr.util import (is_total_slice, human_readable_size, normalize_resize_args,
@@ -1745,10 +1745,11 @@ class Array(object):
                 chunk = f.decode(chunk)
 
         # view as numpy array with correct dtype
+        chunk = ensure_ndarray(chunk)
         if self._dtype == object:
             # special case object dtype, because incorrect handling can lead to
             # segfaults and other bad things happening
-            if isinstance(chunk, np.ndarray) and chunk.dtype == object:
+            if chunk.dtype == object:
                 # chunk is already of correct dtype, good to carry on
                 # flatten just to be sure we can reshape later
                 chunk = chunk.reshape(-1, order='A')

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -8,7 +8,7 @@ import re
 
 
 import numpy as np
-from numcodecs.compat import ensure_ndarray, ensure_contiguous_ndarray
+from numcodecs.compat import ensure_ndarray
 
 
 from zarr.util import (is_total_slice, human_readable_size, normalize_resize_args,
@@ -1761,7 +1761,7 @@ class Array(object):
                 # array during decoding.
                 raise RuntimeError('cannot read object array without object codec')
         else:
-            chunk = ensure_contiguous_ndarray(chunk).view(self._dtype)
+            chunk = chunk.reshape(-1, order='A').view(self._dtype)
 
         # ensure correct chunk shape
         chunk = chunk.reshape(self._chunks, order=self._order)

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -5,9 +5,10 @@ import base64
 
 
 import numpy as np
+from numcodecs.compat import ensure_bytes
 
 
-from zarr.compat import PY2, binary_type, Mapping
+from zarr.compat import PY2, Mapping
 from zarr.errors import MetadataError
 
 
@@ -15,14 +16,9 @@ ZARR_FORMAT = 2
 
 
 def ensure_str(s):
-    if PY2:  # pragma: py3 no cover
-        # noinspection PyUnresolvedReferences
-        if isinstance(s, buffer):  # noqa
-            s = str(s)
-    else:  # pragma: py2 no cover
-        if isinstance(s, memoryview):
-            s = s.tobytes()
-        if isinstance(s, binary_type):
+    if not isinstance(s, str):
+        s = ensure_bytes(s)
+        if not PY2:  # pragma: py2 no cover
             s = s.decode('ascii')
     return s
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -38,8 +38,9 @@ from zarr.util import (normalize_shape, normalize_chunks, normalize_order,
                        normalize_storage_path, buffer_size,
                        normalize_fill_value, nolock, normalize_dtype)
 from zarr.meta import encode_array_metadata, encode_group_metadata
-from zarr.compat import PY2, binary_type, OrderedDict_move_to_end
+from zarr.compat import PY2, OrderedDict_move_to_end
 from numcodecs.registry import codec_registry
+from numcodecs.compat import ensure_bytes
 from zarr.errors import (err_contains_group, err_contains_array, err_bad_compressor,
                          err_fspath_exists_notdir, err_read_only, MetadataError)
 
@@ -442,23 +443,6 @@ def _init_group_metadata(store, overwrite=False, path=None, chunk_store=None):
     meta = dict()
     key = _path_to_prefix(path) + group_meta_key
     store[key] = encode_group_metadata(meta)
-
-
-def ensure_bytes(s):
-    if isinstance(s, binary_type):
-        return s
-    if isinstance(s, np.ndarray):
-        if PY2:  # pragma: py3 no cover
-            # noinspection PyArgumentList
-            return s.tostring(order='A')
-        else:  # pragma: py2 no cover
-            # noinspection PyArgumentList
-            return s.tobytes(order='A')
-    if hasattr(s, 'tobytes'):
-        return s.tobytes()
-    if PY2 and hasattr(s, 'tostring'):  # pragma: py3 no cover
-        return s.tostring()
-    return memoryview(s).tobytes()
 
 
 def _dict_store_keys(d, prefix='', cls=dict):

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -31,16 +31,13 @@ import glob
 import warnings
 
 
-import numpy as np
-
-
 from zarr.util import (normalize_shape, normalize_chunks, normalize_order,
                        normalize_storage_path, buffer_size,
                        normalize_fill_value, nolock, normalize_dtype)
 from zarr.meta import encode_array_metadata, encode_group_metadata
 from zarr.compat import PY2, OrderedDict_move_to_end
 from numcodecs.registry import codec_registry
-from numcodecs.compat import ensure_bytes
+from numcodecs.compat import ensure_bytes, ensure_contiguous_ndarray
 from zarr.errors import (err_contains_group, err_contains_array, err_bad_compressor,
                          err_fspath_exists_notdir, err_read_only, MetadataError)
 
@@ -725,9 +722,8 @@ class DirectoryStore(MutableMapping):
 
     def __setitem__(self, key, value):
 
-        # handle F-contiguous numpy arrays
-        if isinstance(value, np.ndarray) and value.flags.f_contiguous:
-            value = ensure_bytes(value)
+        # coerce to flat, contiguous array (ideally without copying)
+        value = ensure_contiguous_ndarray(value)
 
         # destination path for key
         file_path = os.path.join(self.path, key)
@@ -1176,7 +1172,7 @@ class ZipStore(MutableMapping):
     def __setitem__(self, key, value):
         if self.mode == 'r':
             err_read_only()
-        value = ensure_bytes(value)
+        value = ensure_contiguous_ndarray(value)
         with self.mutex:
             self.zf.writestr(key, value)
 

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -982,7 +982,7 @@ class TestArray(unittest.TestCase):
         z[0] = 'foo'
         assert z[0] == 'foo'
         z[1] = b'bar'
-        assert z[1] == 'bar'  # msgpack gets this wrong
+        assert z[1] == b'bar'
         z[2] = 1
         assert z[2] == 1
         z[3] = [2, 4, 6, 'baz']

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
-import operator
 from textwrap import TextWrapper, dedent
 import numbers
 import uuid
@@ -10,10 +9,11 @@ import inspect
 from asciitree import BoxStyle, LeftAligned
 from asciitree.traversal import Traversal
 import numpy as np
+from numcodecs.compat import ensure_ndarray
 from numcodecs.registry import codec_registry
 
 
-from zarr.compat import PY2, reduce, text_type, binary_type
+from zarr.compat import PY2, text_type, binary_type
 
 
 # codecs to use for object dtype convenience API
@@ -314,17 +314,7 @@ def normalize_storage_path(path):
 
 
 def buffer_size(v):
-    from array import array as _stdlib_array
-    if PY2 and isinstance(v, _stdlib_array):  # pragma: py3 no cover
-        # special case array.array because does not support buffer
-        # interface in PY2
-        return v.buffer_info()[1] * v.itemsize
-    else:  # pragma: py2 no cover
-        v = memoryview(v)
-        if v.shape:
-            return reduce(operator.mul, v.shape) * v.itemsize
-        else:
-            return v.itemsize
+    return ensure_ndarray(v).nbytes
 
 
 def info_text_report(items):


### PR DESCRIPTION
Follow-up to PR ( https://github.com/zarr-developers/zarr/pull/347 )

As there are some critical fixes and needed features in the latest Numcodecs, this bumps our lower bound to the latest version. Pulls most of the content from the aforementioned PR. Drops some commits that have been broken out into subsequent PRs to keep this focused on the Numcodecs upgrade. Does some refactoring and cleanup of internal functions thanks to utility functions now included in Numcodecs.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
