### PR TITLE
Skip coverage of temp file cleanup

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -778,7 +778,7 @@ class DirectoryStore(MutableMapping):
 
         finally:
             # clean up if temp file still exists for whatever reason
-            if temp_path is not None and os.path.exists(temp_path):
+            if temp_path is not None and os.path.exists(temp_path):  # pragma: no cover
                 os.remove(temp_path)
 
     def __delitem__(self, key):


### PR DESCRIPTION
In the ideal case, this cleanup step never happens on CI as the file got moved into place and so no longer exists at the old location. Given this, we ignore coverage on this line.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
