### PR TITLE
Special case chunk encoding for `dict` chunk store

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -56,6 +56,11 @@ Bug fixes
 * Always use a ``tuple`` when indexing a NumPy ``ndarray``.
   By :user:`John Kirkham <jakirkham>`, :issue:`376`
 
+* Ensure when ``Array`` uses a ``dict``-based chunk store that it only contains
+  ``bytes`` to facilitate comparisons and protect against writes. Drop the copy
+  for the no filter/compressor case as this handles that case.
+  By :user:`John Kirkham <jakirkham>`, :issue:`359`
+
 Maintenance
 ~~~~~~~~~~~
 

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -8,7 +8,7 @@ import re
 
 
 import numpy as np
-from numcodecs.compat import ensure_ndarray
+from numcodecs.compat import ensure_bytes, ensure_ndarray
 
 
 from zarr.util import (is_total_slice, human_readable_size, normalize_resize_args,
@@ -1787,6 +1787,10 @@ class Array(object):
             cdata = self._compressor.encode(chunk)
         else:
             cdata = chunk
+
+        # ensure in-memory data is immutable and easy to compare
+        if isinstance(self.chunk_store, dict):
+            cdata = ensure_bytes(cdata)
 
         return cdata
 

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1677,21 +1677,11 @@ class Array(object):
 
             else:
 
-                if not self._compressor and not self._filters:
-
-                    # https://github.com/alimanfoo/zarr/issues/79
-                    # Ensure a copy is taken so we don't end up storing
-                    # a view into someone else's array.
-                    # N.B., this assumes that filters or compressor always
-                    # take a copy and never attempt to apply encoding in-place.
-                    chunk = np.array(value, dtype=self._dtype, order=self._order)
-
+                # ensure array is contiguous
+                if self._order == 'F':
+                    chunk = np.asfortranarray(value, dtype=self._dtype)
                 else:
-                    # ensure array is contiguous
-                    if self._order == 'F':
-                        chunk = np.asfortranarray(value, dtype=self._dtype)
-                    else:
-                        chunk = np.ascontiguousarray(value, dtype=self._dtype)
+                    chunk = np.ascontiguousarray(value, dtype=self._dtype)
 
         else:
             # partially replace the contents of this chunk

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -1725,6 +1725,9 @@ class CustomMapping(object):
     def keys(self):
         return self.inner.keys()
 
+    def values(self):
+        return self.inner.values()
+
     def get(self, item, default=None):
         try:
             return self.inner[item]

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -23,6 +23,7 @@ from zarr.compat import PY2, text_type, binary_type, zip_longest
 from zarr.util import buffer_size
 from numcodecs import (Delta, FixedScaleOffset, Zlib, Blosc, BZ2, MsgPack, Pickle,
                        Categorize, JSON, VLenUTF8, VLenBytes, VLenArray)
+from numcodecs.compat import ensure_ndarray
 from numcodecs.tests.common import greetings
 
 
@@ -82,6 +83,18 @@ class TestArray(unittest.TestCase):
         init_array(store, **kwargs)
         return Array(store, read_only=read_only, cache_metadata=cache_metadata,
                      cache_attrs=cache_attrs)
+
+    def test_store_has_binary_values(self):
+        # Initialize array
+        np.random.seed(42)
+        z = self.create_array(shape=(1050,), chunks=100, dtype='f8', compressor=[])
+        z[:] = np.random.random(z.shape)
+
+        for v in z.chunk_store.values():
+            try:
+                ensure_ndarray(v)
+            except TypeError:
+                pytest.fail("Non-bytes-like value: %s" % repr(v))
 
     def test_nbytes_stored(self):
 

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -1878,3 +1878,7 @@ class TestArrayWithStoreCache(TestArray):
         init_array(store, **kwargs)
         return Array(store, read_only=read_only, cache_metadata=cache_metadata,
                      cache_attrs=cache_attrs)
+
+    def test_store_has_bytes_values(self):
+        # skip as the cache has no control over how the store provides values
+        pass

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -23,7 +23,7 @@ from zarr.compat import PY2, text_type, binary_type, zip_longest
 from zarr.util import buffer_size
 from numcodecs import (Delta, FixedScaleOffset, Zlib, Blosc, BZ2, MsgPack, Pickle,
                        Categorize, JSON, VLenUTF8, VLenBytes, VLenArray)
-from numcodecs.compat import ensure_ndarray
+from numcodecs.compat import ensure_bytes, ensure_ndarray
 from numcodecs.tests.common import greetings
 
 
@@ -1767,7 +1767,7 @@ class CustomMapping(object):
         return self.inner[item]
 
     def __setitem__(self, item, value):
-        self.inner[item] = value
+        self.inner[item] = ensure_bytes(value)
 
     def __delitem__(self, key):
         del self.inner[key]

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -96,6 +96,19 @@ class TestArray(unittest.TestCase):
             except TypeError:
                 pytest.fail("Non-bytes-like value: %s" % repr(v))
 
+    def test_store_has_bytes_values(self):
+        # Test that many stores do hold bytes values.
+        # Though this is not a strict requirement.
+        # Should be disabled by any stores that fail this as needed.
+
+        # Initialize array
+        np.random.seed(42)
+        z = self.create_array(shape=(1050,), chunks=100, dtype='f8', compressor=[])
+        z[:] = np.random.random(z.shape)
+
+        # Check in-memory array only contains `bytes`
+        assert all([isinstance(v, binary_type) for v in z.chunk_store.values()])
+
     def test_nbytes_stored(self):
 
         # dict as store

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -93,7 +93,7 @@ class TestArray(unittest.TestCase):
         for v in z.chunk_store.values():
             try:
                 ensure_ndarray(v)
-            except TypeError:
+            except TypeError:  # pragma: no cover
                 pytest.fail("Non-bytes-like value: %s" % repr(v))
 
     def test_store_has_bytes_values(self):

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -1427,6 +1427,9 @@ class TestArrayWithLMDBStore(TestArray):
         return Array(store, read_only=read_only, cache_metadata=cache_metadata,
                      cache_attrs=cache_attrs)
 
+    def test_store_has_bytes_values(self):
+        pass  # returns values as memoryviews/buffers instead of bytes
+
     def test_nbytes_stored(self):
         pass  # not implemented
 


### PR DESCRIPTION
This removes the special case copying of chunks in commit ( https://github.com/zarr-developers/zarr/commit/3c00d52356fb59968d05b8764b05a66c50457850 ). Instead this checks to see if a `dict` instance is being used to back chunk storage. If it is, this coerces the chunk data to `bytes` (if it is not already `bytes`). This avoids a copy for well-defined backends that already protect their data against unwanted tampering. Also continues to avoid copies when compressors and/or filters already return the data as `bytes`. However this will copy in any case where a non-`bytes` object (e.g. an `ndarray`) is placed in the chunk store (e.g. no filters/compressors are used or some specific filter is used at the end). This behavior for `dict`-based chunk stores is analogous to what `DictStore` does currently for stored values.

Note: This also extends to subclasses of `dict`, which include `defaultdict` and `OrderedDict`. It does not include `ChainMap` or `UserDict`; however, it's unclear whether we should be special casing those two as `ChainMap` is meant to provide a unified interface onto many `MutableMapping`s of various kinds and `UserDict` is intended as a clean and simple alternative for subclassing `dict`.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
