### PR TITLE
Use `ensure_ndarray` to view chunk as an array

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -29,7 +29,7 @@ Bug fixes
 
 * The required version of the `numcodecs <http://numcodecs.rtfd.io>`_ package has been upgraded 
   to 0.6.2, which has enabled some code simplification and fixes a failing test involving
-  msgpack encoding. By :user:`John Kirkham <jakirkham>`, :issue:`352`, :issue:`355`, 
+  msgpack encoding. By :user:`John Kirkham <jakirkham>`, :issue:`352`, :issue:`355`,
   :issue:`324`.
 
 * Failing tests related to pickling/unpickling have been fixed. By :user:`Ryan Williams <ryan-williams>`,

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -29,7 +29,7 @@ Bug fixes
 
 * The required version of the `numcodecs <http://numcodecs.rtfd.io>`_ package has been upgraded 
   to 0.6.2, which has enabled some code simplification and fixes a failing test involving
-  msgpack encoding. By :user:`John Kirkham <jakirkham>`, :issue:`352`, :issue:`355`,
+  msgpack encoding. By :user:`John Kirkham <jakirkham>`, :issue:`360`, :issue:`352`, :issue:`355`,
   :issue:`324`.
 
 * Failing tests related to pickling/unpickling have been fixed. By :user:`Ryan Williams <ryan-williams>`,

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1604,10 +1604,7 @@ class Array(object):
                     if self._compressor:
                         self._compressor.decode(cdata, dest)
                     else:
-                        if isinstance(cdata, np.ndarray):
-                            chunk = cdata.view(self._dtype)
-                        else:
-                            chunk = np.frombuffer(cdata, dtype=self._dtype)
+                        chunk = ensure_ndarray(cdata).view(self._dtype)
                         chunk = chunk.reshape(self._chunks, order=self._order)
                         np.copyto(dest, chunk)
                     return


### PR DESCRIPTION
Follow-up to PR ( https://github.com/zarr-developers/zarr/pull/352 )

Simplifies the process of constructing an `ndarray` to view the chunk data when writing the result to a destination. Also removes the last usage of `np.frombuffer` from library code (still used in examples, tests, and docs).

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
