### PR TITLE
Drop temporary workaround for `get_codec`

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -29,8 +29,8 @@ Bug fixes
 
 * The required version of the `numcodecs <http://numcodecs.rtfd.io>`_ package has been upgraded 
   to 0.6.2, which has enabled some code simplification and fixes a failing test involving
-  msgpack encoding. By :user:`John Kirkham <jakirkham>`, :issue:`360`, :issue:`352`, :issue:`355`,
-  :issue:`324`.
+  msgpack encoding. By :user:`John Kirkham <jakirkham>`, :issue:`361`, :issue:`360`, :issue:`352`,
+  :issue:`355`, :issue:`324`.
 
 * Failing tests related to pickling/unpickling have been fixed. By :user:`Ryan Williams <ryan-williams>`,
   :issue:`273`, :issue:`308`.

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -166,9 +166,6 @@ class Array(object):
             if config is None:
                 self._compressor = None
             else:
-                # temporary workaround for
-                # https://github.com/zarr-developers/numcodecs/issues/78
-                config = dict(config)
                 self._compressor = get_codec(config)
 
             # setup filters


### PR DESCRIPTION
Follow-up to PR ( https://github.com/zarr-developers/zarr/pull/352 ) and PR ( https://github.com/zarr-developers/zarr/pull/268 )

This workaround was added because `get_codec` was modifying its argument. However as of Numcodecs 0.6.0, `get_codec` does not modify its argument as it takes a copy and modifies the copy instead. ( https://github.com/zarr-developers/numcodecs/pull/79 ) Given as we now require Numcodecs 0.6.0, this workaround is no longer needed. Hence we drop it.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
