### PR TITLE
Require Xenial and sudo always

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ branches:
   only:
     - master
 
-sudo: false
+dist: xenial
+sudo: true
 
 addons:
   apt:
@@ -17,8 +18,6 @@ matrix:
     - python: 3.5
     - python: 3.6
     - python: 3.7
-      dist: xenial
-      sudo: true
 
 install:
   - pip install -U pip setuptools wheel tox-travis coveralls


### PR DESCRIPTION
Make sure Xenial and sudo are always used. Soon `sudo` will be required and the Ubuntu Precise image retired. Try bumping the image across the board to see if that works for our support Python versions.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
