### PR TITLE
Use `reversed` to iterate through `list` backwards

### DIFF
--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1735,7 +1735,7 @@ class Array(object):
 
         # apply filters
         if self._filters:
-            for f in self._filters[::-1]:
+            for f in reversed(self._filters):
                 chunk = f.decode(chunk)
 
         # view as numpy array with correct dtype


### PR DESCRIPTION
As using slicing syntax on `list`s makes a copy, use `reversed` instead to avoid the copy and just create a generator for iterating through the `list` backwards.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
