### PR TITLE
Always use `tuple`s for multidimensional indexing

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -38,6 +38,9 @@ Bug fixes
 * Ensure ``DictStore`` contains only ``bytes`` to facilitate comparisons and protect against writes.
   By :user:`John Kirkham <jakirkham>`, :issue:`350`
 
+* Always use a ``tuple`` when indexing a NumPy ``ndarray``.
+  By :user:`John Kirkham <jakirkham>`, :issue:`376`
+
 Maintenance
 ~~~~~~~~~~~
 

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1531,6 +1531,7 @@ class Array(object):
                     item = [slice(None)] * self.ndim
                     for a in indexer.drop_axes:
                         item[a] = np.newaxis
+                    item = tuple(item)
                     chunk_value = chunk_value[item]
 
             # put data

--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -513,6 +513,7 @@ def oindex_set(a, selection, value):
         value_selection = [slice(None)] * len(a.shape)
         for i in drop_axes:
             value_selection[i] = np.newaxis
+        value_selection = tuple(value_selection)
         value = value[value_selection]
     a[selection] = value
 


### PR DESCRIPTION
NumPy 1.15.0 deprecates the use of sequences in `ndarray` selection for sequences other than `tuple`s. We have a few cases where we are using `list`s instead as they are mutable. Thus are easier to build up and change. However passing `list`s into `ndarray` selection will cause this `FutureWarning` to be emitted (and will eventually result in an error).

To fix this simply, just convert these `list`s to `tuple`s after we are done changing their contents, but before we use them with `ndarray`s. This works just as well on older versions of NumPy. Avoids the `FutureWarning` in NumPy 1.15.0+. Not to mention this will continue to work on future versions of NumPy, which may change this warning into an error.

xref: https://github.com/numpy/numpy/pull/9686

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
