### PR TITLE
Test the `popitem` method of `MutableMapping`s too

### DIFF
--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -93,6 +93,16 @@ class StoreTests(object):
         with pytest.raises(KeyError):
             store.pop('xxx')
 
+    def test_popitem(self):
+        store = self.create_store()
+        store['foo'] = b'bar'
+        k, v = store.popitem()
+        assert k == 'foo'
+        assert v == b'bar'
+        assert len(store) == 0
+        with pytest.raises(KeyError):
+            store.popitem()
+
     def test_writeable_values(self):
         store = self.create_store()
 
@@ -761,6 +771,13 @@ class TestZipStore(StoreTests, unittest.TestCase):
         store['foo'] = b'bar'
         with pytest.raises(NotImplementedError):
             store.pop('foo')
+
+    def test_popitem(self):
+        # override because not implemented
+        store = self.create_store()
+        store['foo'] = b'bar'
+        with pytest.raises(NotImplementedError):
+            store.popitem()
 
 
 class TestDBMStore(StoreTests, unittest.TestCase):


### PR DESCRIPTION
Adds a test for the `popitem` method of `MutableMapping`'s as well. Typically this is not used, but it does get used in the default `clear` method. Given this method doesn't guarantee an order, use a store with a single-key value pair to simplify the test logic. Also test the case of an empty store to make sure it errors out properly. Override the `popitem` method appropriate for stores that do not handle removal properly.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
