### PR TITLE
Test `pop` with default argument

### DIFF
--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -92,6 +92,8 @@ class StoreTests(object):
         assert len(store) == 0
         with pytest.raises(KeyError):
             store.pop('xxx')
+        v = store.pop('xxx', b'')
+        assert v == b''
 
     def test_writeable_values(self):
         store = self.create_store()

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -94,6 +94,8 @@ class StoreTests(object):
             store.pop('xxx')
         v = store.pop('xxx', b'')
         assert v == b''
+        v = store.pop('xxx', None)
+        assert v is None
 
     def test_writeable_values(self):
         store = self.create_store()

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -92,6 +92,8 @@ class StoreTests(object):
         assert len(store) == 0
         with pytest.raises(KeyError):
             store.pop('xxx')
+        v = store.pop('xxx', b'default')
+        assert v == b'default'
         v = store.pop('xxx', b'')
         assert v == b''
         v = store.pop('xxx', None)


### PR DESCRIPTION
Adds another case to `test_pop` for stores generally, which merely tests if `pop` can handle the default argument correctly when no key can be found.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
