### PR TITLE
Use binary_type in MongoDBStore.__getitem__ for Python 2 only

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -2147,7 +2147,7 @@ class MongoDBStore(MutableMapping):
         if doc is None:
             raise KeyError(key)
         else:
-            return binary_type(doc[self._value])
+            return doc[self._value]
 
     def __setitem__(self, key, value):
         value = ensure_bytes(value)

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -2147,7 +2147,15 @@ class MongoDBStore(MutableMapping):
         if doc is None:
             raise KeyError(key)
         else:
-            return doc[self._value]
+            value = doc[self._value]
+
+            # Coerce `bson.Binary` to `bytes` type on Python 2.
+            # PyMongo handles this conversion for us on Python 3.
+            # ref: http://api.mongodb.com/python/current/python3.html#id3
+            if PY2:  # pragma: py3 no cover
+                value = binary_type(value)
+
+            return value
 
     def __setitem__(self, key, value):
         value = ensure_bytes(value)


### PR DESCRIPTION
Previously there were some [test failures on Python 2]( https://travis-ci.org/zarr-developers/zarr/jobs/473753393#L2148 ) and referenced in [this comment (and later discussion)]( https://github.com/zarr-developers/zarr/pull/372#issuecomment-450667294 ). Turns out on Python 2 a `bson.Binary` instance is returned, which subclasses `bytes`, as [explained in the docs]( http://api.mongodb.com/python/current/python3.html#id3 ). So the coercion to `bytes` is only needed on Python 2 to convert `bson.Binary` to `bytes`. As Python 3 already returns a `bytes` instance, there is nothing we need to do there. Thus we restrict the `binary_type` call to Python 2. Should avoid a copy on Python 3.

xref: https://github.com/zarr-developers/zarr/pull/372

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
