### PR TITLE
Set pycodestyle's line length limit to flake8's

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -52,3 +52,6 @@ commands =
 
 [flake8]
 max-line-length = 100
+
+[pycodestyle]
+max-line-length = 100

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -40,8 +40,7 @@ from zarr.meta import encode_array_metadata, encode_group_metadata
 from zarr.compat import PY2, OrderedDict_move_to_end, binary_type
 from numcodecs.registry import codec_registry
 from numcodecs.compat import ensure_bytes, ensure_contiguous_ndarray
-from zarr.errors import (err_contains_group, err_contains_array, err_bad_compressor,
-                         err_fspath_exists_notdir, err_read_only, MetadataError)
+from zarr.errors import (err_contains_group, err_contains_array, err_bad_compressor, err_fspath_exists_notdir, err_read_only, MetadataError)
 
 
 array_meta_key = '.zarray'


### PR DESCRIPTION
This should make sure that pycodestyle doesn't raise false positives due to long lines in our code. Hopefully should also help with pep8speaks, which uses pycodestyle.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
