### PR TITLE
Test Array storing different compressors, endian and attributes

### DIFF
--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -1189,6 +1189,16 @@ class TestArray(unittest.TestCase):
             for expect, actual in zip_longest(a, z):
                 assert_array_equal(expect, actual)
 
+    def test_endian(self):
+        dtype = np.dtype('float32')
+        a1 = self.create_array(shape=1000, chunks=100, dtype=dtype.newbyteorder('<'))
+        a1[:] = 1
+        x1 = a1[:]
+        a2 = self.create_array(shape=1000, chunks=100, dtype=dtype.newbyteorder('>'))
+        a2[:] = 1
+        x2 = a2[:]
+        assert_array_equal(x1, x2)
+
 
 class TestArrayWithPath(TestArray):
 

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, print_function, division
 import unittest
 from tempfile import mkdtemp, mktemp
 import atexit
+import json
 import shutil
 import pickle
 import os
@@ -20,6 +21,7 @@ from zarr.storage import (DirectoryStore, init_array, init_group, NestedDirector
 from zarr.core import Array
 from zarr.errors import PermissionError
 from zarr.compat import PY2, text_type, binary_type, zip_longest
+from zarr.meta import ensure_str
 from zarr.util import buffer_size
 from numcodecs import (Delta, FixedScaleOffset, Zlib, Blosc, BZ2, MsgPack, Pickle,
                        Categorize, JSON, VLenUTF8, VLenBytes, VLenArray)
@@ -1198,6 +1200,16 @@ class TestArray(unittest.TestCase):
         a2[:] = 1
         x2 = a2[:]
         assert_array_equal(x1, x2)
+
+    def test_attributes(self):
+        a = self.create_array(shape=10, chunks=10, dtype='i8')
+        a.attrs['foo'] = 'bar'
+        attrs = json.loads(ensure_str(a.store[a.attrs.key]))
+        assert 'foo' in attrs and attrs['foo'] == 'bar'
+        a.attrs['bar'] = 'foo'
+        attrs = json.loads(ensure_str(a.store[a.attrs.key]))
+        assert 'foo' in attrs and attrs['foo'] == 'bar'
+        assert 'bar' in attrs and attrs['bar'] == 'foo'
 
 
 class TestArrayWithPath(TestArray):

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -23,7 +23,7 @@ from zarr.errors import PermissionError
 from zarr.compat import PY2, text_type, binary_type, zip_longest
 from zarr.meta import ensure_str
 from zarr.util import buffer_size
-from numcodecs import (Delta, FixedScaleOffset, Zlib, Blosc, BZ2, MsgPack, Pickle,
+from numcodecs import (Delta, FixedScaleOffset, LZ4, GZip, Zlib, Blosc, BZ2, MsgPack, Pickle,
                        Categorize, JSON, VLenUTF8, VLenBytes, VLenArray)
 from numcodecs.tests.common import greetings
 
@@ -1190,6 +1190,19 @@ class TestArray(unittest.TestCase):
             z[:] = a
             for expect, actual in zip_longest(a, z):
                 assert_array_equal(expect, actual)
+
+    def test_compressors(self):
+        compressors = [
+            None, BZ2(), Blosc(), LZ4(), Zlib(), GZip()
+        ]
+        if LZMA:
+            compressors.append(LZMA())
+        for compressor in compressors:
+            a = self.create_array(shape=1000, chunks=100, compressor=compressor)
+            a[0:100] = 1
+            assert np.all(a[0:100] == 1)
+            a[:] = 1
+            assert np.all(a[:] == 1)
 
     def test_endian(self):
         dtype = np.dtype('float32')


### PR DESCRIPTION
Pulled from PR ( https://github.com/zarr-developers/zarr/pull/309 ) and added to `TestArray` so that it can be applied to multiple storage classes. Credits to @funkey for adding these tests.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
