### PR TITLE
Test store keys are all text

### DIFF
--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -86,6 +86,21 @@ class TestArray(unittest.TestCase):
         return Array(store, read_only=read_only, cache_metadata=cache_metadata,
                      cache_attrs=cache_attrs)
 
+    def test_store_has_text_keys(self):
+        # Initialize array
+        np.random.seed(42)
+        z = self.create_array(shape=(1050,), chunks=100, dtype='f8', compressor=[])
+        z[:] = np.random.random(z.shape)
+
+        if PY2:  # pragma: py3 no cover
+            expected_type = (str, text_type)
+        else:    # pragma: py2 no cover
+            expected_type = text_type
+
+        for k in z.chunk_store.keys():
+            if not isinstance(k, expected_type):  # pragma: no cover
+                pytest.fail("Non-text key: %s" % repr(k))
+
     def test_store_has_binary_values(self):
         # Initialize array
         np.random.seed(42)


### PR DESCRIPTION
Adds a test for all stores to ensure that all keys are text.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
