### PR TITLE
Skip datetime, timedelta, and complex with N5Store

### DIFF
--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -1557,6 +1557,30 @@ class TestArrayWithN5Store(TestArrayWithDirectoryStore):
         with pytest.raises(TypeError):
             self.check_structured_array(d, fill_values)
 
+    def test_dtypes(self):
+
+        # integers
+        for dtype in 'u1', 'u2', 'u4', 'u8', 'i1', 'i2', 'i4', 'i8':
+            z = self.create_array(shape=10, chunks=3, dtype=dtype)
+            assert z.dtype == np.dtype(dtype)
+            a = np.arange(z.shape[0], dtype=dtype)
+            z[:] = a
+            assert_array_equal(a, z[:])
+
+        # floats
+        for dtype in 'f2', 'f4', 'f8':
+            z = self.create_array(shape=10, chunks=3, dtype=dtype)
+            assert z.dtype == np.dtype(dtype)
+            a = np.linspace(0, 1, z.shape[0], dtype=dtype)
+            z[:] = a
+            assert_array_almost_equal(a, z[:])
+
+        # check that datetime generic units are not allowed
+        with pytest.raises(ValueError):
+            self.create_array(shape=100, dtype='M8')
+        with pytest.raises(ValueError):
+            self.create_array(shape=100, dtype='m8')
+
     def test_object_arrays(self):
 
         # an object_codec is required for object arrays


### PR DESCRIPTION
The N5 spec does not currently list support for datetime, timedelta, and complex typed data. So customize `test_dtype` for `N5Store` to avoid these and instead focus on the types `N5Store` does support. Should fix the [CI failure on `master`]( https://travis-ci.org/zarr-developers/zarr/builds/498601006 ) accidentally introduced by PR ( https://github.com/zarr-developers/zarr/pull/363 ).

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
