### PR TITLE
Make azure-storage-blob optional for testing

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,6 +1,18 @@
 Release notes
 =============
 
+.. _release_2.3.1:
+
+2.3.1
+-----
+
+Bug fixes
+~~~~~~~~~
+
+* Makes ``azure-storage-blob`` optional for testing.
+  By :user:`John Kirkham <jakirkham>`; :issue:`419`, :issue:`420`
+
+
 .. _release_2.3.0:
 
 2.3.0

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -3,8 +3,8 @@ Release notes
 
 .. _release_2.3.0:
 
-2.3.0 (Work in Progress)
-------------------------
+2.3.0
+-----
 
 Enhancements
 ~~~~~~~~~~~~

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -13,7 +13,11 @@ import warnings
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 import pytest
-from azure.storage.blob import BlockBlobService
+
+try:
+    import azure.storage.blob as asb
+except ImportError:
+    asb = None
 
 
 from zarr.storage import (DirectoryStore, init_array, init_group, NestedDirectoryStore,
@@ -1409,11 +1413,13 @@ class TestArrayWithDirectoryStore(TestArray):
         assert expect_nbytes_stored == z.nbytes_stored
 
 
+@pytest.mark.skipif(asb is None,
+                    reason="azure-blob-storage could not be imported")
 class TestArrayWithABSStore(TestArray):
 
     @staticmethod
     def absstore():
-        blob_client = BlockBlobService(is_emulated=True)
+        blob_client = asb.BlockBlobService(is_emulated=True)
         blob_client.delete_container('test')
         blob_client.create_container('test')
         store = ABSStore(container='test', prefix='zarrtesting/', account_name='foo',

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -16,7 +16,7 @@ import pytest
 
 try:
     import azure.storage.blob as asb
-except ImportError:
+except ImportError:  # pragma: no cover
     asb = None
 
 

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -13,7 +13,11 @@ import warnings
 import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
-from azure.storage.blob import BlockBlobService
+
+try:
+    import azure.storage.blob as asb
+except ImportError:
+    asb = None
 
 
 from zarr.storage import (DictStore, DirectoryStore, ZipStore, init_group, init_array,
@@ -865,11 +869,13 @@ class TestGroupWithDirectoryStore(TestGroup):
         return store, None
 
 
+@pytest.mark.skipif(asb is None,
+                    reason="azure-blob-storage could not be imported")
 class TestGroupWithABSStore(TestGroup):
 
     @staticmethod
     def create_store():
-        blob_client = BlockBlobService(is_emulated=True)
+        blob_client = asb.BlockBlobService(is_emulated=True)
         blob_client.delete_container('test')
         blob_client.create_container('test')
         store = ABSStore(container='test', prefix='zarrtesting/', account_name='foo',

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -16,7 +16,7 @@ import pytest
 
 try:
     import azure.storage.blob as asb
-except ImportError:
+except ImportError:  # pragma: no cover
     asb = None
 
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -15,7 +15,11 @@ from pickle import PicklingError
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 import pytest
-from azure.storage.blob import BlockBlobService
+
+try:
+    import azure.storage.blob as asb
+except ImportError:
+    asb = None
 
 
 from zarr.storage import (init_array, array_meta_key, attrs_key, DictStore,
@@ -1514,10 +1518,12 @@ def test_format_compatibility():
                 assert compressor.get_config() == z.compressor.get_config()
 
 
+@pytest.mark.skipif(asb is None,
+                    reason="azure-blob-storage could not be imported")
 class TestABSStore(StoreTests, unittest.TestCase):
 
     def create_store(self):
-        blob_client = BlockBlobService(is_emulated=True)
+        blob_client = asb.BlockBlobService(is_emulated=True)
         blob_client.delete_container('test')
         blob_client.create_container('test')
         store = ABSStore(container='test', prefix='zarrtesting/', account_name='foo',

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -18,7 +18,7 @@ import pytest
 
 try:
     import azure.storage.blob as asb
-except ImportError:
+except ImportError:  # pragma: no cover
     asb = None
 
 


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/zarr/issues/419

Updates the tests to make `azure-storage-blob` an optional testing requirement.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
