### PR TITLE
Coerce data to text for JSON parsing

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,6 +1,18 @@
 Release notes
 =============
 
+.. _release_2.3.2:
+
+2.3.2
+-----
+
+Bug fixes
+~~~~~~~~~
+
+* Coerce data to text for JSON parsing.
+  By :user:`John Kirkham <jakirkham>`; :issue:`429`
+
+
 .. _release_2.3.1:
 
 2.3.1

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -15,7 +15,7 @@ from zarr.storage import contains_array, contains_group
 from zarr.errors import err_path_not_found, CopyError
 from zarr.util import normalize_storage_path, TreeViewer, buffer_size
 from zarr.compat import PY2, text_type
-from zarr.meta import ensure_str, json_dumps
+from zarr.meta import ensure_text_type, json_dumps
 
 
 # noinspection PyShadowingBuiltins
@@ -1123,7 +1123,7 @@ def consolidate_metadata(store, metadata_key='.zmetadata'):
     out = {
         'zarr_consolidated_format': 1,
         'metadata': {
-            key: json.loads(ensure_str(store[key]))
+            key: json.loads(ensure_text_type(store[key]))
             for key in store if is_zarr_key(key)
         }
     }

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -15,7 +15,7 @@ from zarr.storage import contains_array, contains_group
 from zarr.errors import err_path_not_found, CopyError
 from zarr.util import normalize_storage_path, TreeViewer, buffer_size
 from zarr.compat import PY2, text_type
-from zarr.meta import ensure_text_type, json_dumps
+from zarr.meta import json_dumps, json_loads
 
 
 # noinspection PyShadowingBuiltins
@@ -1112,8 +1112,6 @@ def consolidate_metadata(store, metadata_key='.zmetadata'):
     open_consolidated
 
     """
-    import json
-
     store = normalize_store_arg(store)
 
     def is_zarr_key(key):
@@ -1123,7 +1121,7 @@ def consolidate_metadata(store, metadata_key='.zmetadata'):
     out = {
         'zarr_consolidated_format': 1,
         'metadata': {
-            key: json.loads(ensure_text_type(store[key]))
+            key: json_loads(store[key])
             for key in store if is_zarr_key(key)
         }
     }

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -47,8 +47,7 @@ def parse_metadata(s):
 
     else:
         # assume metadata needs to be parsed as JSON
-        s = ensure_text_type(s)
-        meta = json.loads(s)
+        meta = json_loads(s)
 
     return meta
 

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -42,7 +42,7 @@ def parse_metadata(s):
 
     else:
         # assume metadata needs to be parsed as JSON
-        s = ensure_str(s)
+        s = ensure_text_type(s)
         meta = json.loads(s)
 
     return meta

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -29,6 +29,11 @@ def json_dumps(o):
                       separators=(',', ': '))
 
 
+def json_loads(s):
+    """Read JSON in a consistent way."""
+    return json.loads(ensure_text_type(s))
+
+
 def parse_metadata(s):
 
     # Here we allow that a store may return an already-parsed metadata object,

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -2,24 +2,24 @@
 from __future__ import absolute_import, print_function, division
 import json
 import base64
+import codecs
 
 
 import numpy as np
-from numcodecs.compat import ensure_bytes
+from numcodecs.compat import ensure_contiguous_ndarray
 
 
-from zarr.compat import PY2, Mapping
+from zarr.compat import PY2, Mapping, text_type
 from zarr.errors import MetadataError
 
 
 ZARR_FORMAT = 2
 
 
-def ensure_str(s):
-    if not isinstance(s, str):
-        s = ensure_bytes(s)
-        if not PY2:  # pragma: py2 no cover
-            s = s.decode('ascii')
+def ensure_text_type(s):
+    if not isinstance(s, text_type):
+        s = ensure_contiguous_ndarray(s)
+        s = codecs.decode(s, 'ascii')
     return s
 
 

--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -2,7 +2,7 @@
 """This module contains a storage class and codec to support the N5 format.
 """
 from __future__ import absolute_import, division
-from .meta import ZARR_FORMAT, ensure_text_type, json_dumps
+from .meta import ZARR_FORMAT, json_dumps, json_loads
 from .storage import (
         NestedDirectoryStore,
         group_meta_key as zarr_group_meta_key,
@@ -12,7 +12,6 @@ from .storage import (
 from numcodecs.abc import Codec
 from numcodecs.compat import ndarray_copy
 from numcodecs.registry import register_codec, get_codec
-import json
 import numpy as np
 import struct
 import sys
@@ -103,9 +102,8 @@ class N5Store(NestedDirectoryStore):
 
             key = key.replace(zarr_group_meta_key, n5_attrs_key)
 
-            value = ensure_text_type(value)
             n5_attrs = self._load_n5_attrs(key)
-            n5_attrs.update(**group_metadata_to_n5(json.loads(value)))
+            n5_attrs.update(**group_metadata_to_n5(json_loads(value)))
 
             value = json_dumps(n5_attrs).encode('ascii')
 
@@ -113,9 +111,8 @@ class N5Store(NestedDirectoryStore):
 
             key = key.replace(zarr_array_meta_key, n5_attrs_key)
 
-            value = ensure_text_type(value)
             n5_attrs = self._load_n5_attrs(key)
-            n5_attrs.update(**array_metadata_to_n5(json.loads(value)))
+            n5_attrs.update(**array_metadata_to_n5(json_loads(value)))
 
             value = json_dumps(n5_attrs).encode('ascii')
 
@@ -123,9 +120,8 @@ class N5Store(NestedDirectoryStore):
 
             key = key.replace(zarr_attrs_key, n5_attrs_key)
 
-            value = ensure_text_type(value)
             n5_attrs = self._load_n5_attrs(key)
-            zarr_attrs = json.loads(value)
+            zarr_attrs = json_loads(value)
 
             for k in n5_keywords:
                 if k in zarr_attrs.keys():
@@ -246,8 +242,7 @@ class N5Store(NestedDirectoryStore):
     def _load_n5_attrs(self, path):
         try:
             s = super(N5Store, self).__getitem__(path)
-            s = ensure_text_type(s)
-            return json.loads(s)
+            return json_loads(s)
         except KeyError:
             return {}
 

--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -2,7 +2,7 @@
 """This module contains a storage class and codec to support the N5 format.
 """
 from __future__ import absolute_import, division
-from .meta import ZARR_FORMAT, ensure_str, json_dumps
+from .meta import ZARR_FORMAT, ensure_text_type, json_dumps
 from .storage import (
         NestedDirectoryStore,
         group_meta_key as zarr_group_meta_key,
@@ -103,7 +103,7 @@ class N5Store(NestedDirectoryStore):
 
             key = key.replace(zarr_group_meta_key, n5_attrs_key)
 
-            value = ensure_str(value)
+            value = ensure_text_type(value)
             n5_attrs = self._load_n5_attrs(key)
             n5_attrs.update(**group_metadata_to_n5(json.loads(value)))
 
@@ -113,7 +113,7 @@ class N5Store(NestedDirectoryStore):
 
             key = key.replace(zarr_array_meta_key, n5_attrs_key)
 
-            value = ensure_str(value)
+            value = ensure_text_type(value)
             n5_attrs = self._load_n5_attrs(key)
             n5_attrs.update(**array_metadata_to_n5(json.loads(value)))
 
@@ -123,7 +123,7 @@ class N5Store(NestedDirectoryStore):
 
             key = key.replace(zarr_attrs_key, n5_attrs_key)
 
-            value = ensure_str(value)
+            value = ensure_text_type(value)
             n5_attrs = self._load_n5_attrs(key)
             zarr_attrs = json.loads(value)
 
@@ -246,7 +246,7 @@ class N5Store(NestedDirectoryStore):
     def _load_n5_attrs(self, path):
         try:
             s = super(N5Store, self).__getitem__(path)
-            s = ensure_str(s)
+            s = ensure_text_type(s)
             return json.loads(s)
         except KeyError:
             return {}

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -2297,13 +2297,6 @@ class MongoDBStore(MutableMapping):
             raise KeyError(key)
         else:
             value = doc[self._value]
-
-            # Coerce `bson.Binary` to `bytes` type on Python 2.
-            # PyMongo handles this conversion for us on Python 3.
-            # ref: http://api.mongodb.com/python/current/python3.html#id3
-            if PY2:  # pragma: py3 no cover
-                value = binary_type(value)
-
             return value
 
     def __setitem__(self, key, value):

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -2296,8 +2296,7 @@ class MongoDBStore(MutableMapping):
         if doc is None:
             raise KeyError(key)
         else:
-            value = doc[self._value]
-            return value
+            return doc[self._value]
 
     def __setitem__(self, key, value):
         value = ensure_bytes(value)

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -38,7 +38,7 @@ from zarr.util import (normalize_shape, normalize_chunks, normalize_order,
                        normalize_storage_path, buffer_size,
                        normalize_fill_value, nolock, normalize_dtype)
 from zarr.meta import encode_array_metadata, encode_group_metadata
-from zarr.compat import PY2, OrderedDict_move_to_end, binary_type
+from zarr.compat import PY2, OrderedDict_move_to_end
 from numcodecs.registry import codec_registry
 from numcodecs.compat import ensure_bytes, ensure_contiguous_ndarray
 from zarr.errors import (err_contains_group, err_contains_array, err_bad_compressor,

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, print_function, division
 import unittest
 from tempfile import mkdtemp, mktemp
 import atexit
-import json
 import shutil
 import pickle
 import os
@@ -26,7 +25,7 @@ from zarr.storage import (DirectoryStore, init_array, init_group, NestedDirector
 from zarr.core import Array
 from zarr.errors import PermissionError
 from zarr.compat import PY2, text_type, binary_type, zip_longest
-from zarr.meta import ensure_text_type
+from zarr.meta import json_loads
 from zarr.util import buffer_size
 from zarr.n5 import n5_keywords, N5Store
 from numcodecs import (Delta, FixedScaleOffset, LZ4, GZip, Zlib, Blosc, BZ2, MsgPack, Pickle,
@@ -1273,10 +1272,10 @@ class TestArray(unittest.TestCase):
     def test_attributes(self):
         a = self.create_array(shape=10, chunks=10, dtype='i8')
         a.attrs['foo'] = 'bar'
-        attrs = json.loads(ensure_text_type(a.store[a.attrs.key]))
+        attrs = json_loads(a.store[a.attrs.key])
         assert 'foo' in attrs and attrs['foo'] == 'bar'
         a.attrs['bar'] = 'foo'
-        attrs = json.loads(ensure_text_type(a.store[a.attrs.key]))
+        attrs = json_loads(a.store[a.attrs.key])
         assert 'foo' in attrs and attrs['foo'] == 'bar'
         assert 'bar' in attrs and attrs['bar'] == 'foo'
 

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -26,7 +26,7 @@ from zarr.storage import (DirectoryStore, init_array, init_group, NestedDirector
 from zarr.core import Array
 from zarr.errors import PermissionError
 from zarr.compat import PY2, text_type, binary_type, zip_longest
-from zarr.meta import ensure_str
+from zarr.meta import ensure_text_type
 from zarr.util import buffer_size
 from zarr.n5 import n5_keywords, N5Store
 from numcodecs import (Delta, FixedScaleOffset, LZ4, GZip, Zlib, Blosc, BZ2, MsgPack, Pickle,
@@ -1273,10 +1273,10 @@ class TestArray(unittest.TestCase):
     def test_attributes(self):
         a = self.create_array(shape=10, chunks=10, dtype='i8')
         a.attrs['foo'] = 'bar'
-        attrs = json.loads(ensure_str(a.store[a.attrs.key]))
+        attrs = json.loads(ensure_text_type(a.store[a.attrs.key]))
         assert 'foo' in attrs and attrs['foo'] == 'bar'
         a.attrs['bar'] = 'foo'
-        attrs = json.loads(ensure_str(a.store[a.attrs.key]))
+        attrs = json.loads(ensure_text_type(a.store[a.attrs.key]))
         assert 'foo' in attrs and attrs['foo'] == 'bar'
         assert 'bar' in attrs and attrs['bar'] == 'foo'
 


### PR DESCRIPTION
Cleans up some Python 2/3 code for handling JSON parsing by simply always coercing metadata to text regardless of Python version.

xref: https://github.com/zarr-developers/zarr/pull/372
xref: https://github.com/zarr-developers/zarr/pull/401

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)