### PR TITLE
Collect JSON utility functions

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -9,8 +9,8 @@ Release notes
 Bug fixes
 ~~~~~~~~~
 
-* Coerce data to text for JSON parsing.
-  By :user:`John Kirkham <jakirkham>`; :issue:`429`
+* Add and use utility functions to simplify reading and writing JSON.
+  By :user:`John Kirkham <jakirkham>`; :issue:`429`, :issue:`430`
 
 
 .. _release_2.3.1:

--- a/zarr/attrs.py
+++ b/zarr/attrs.py
@@ -113,8 +113,8 @@ class Attributes(MutableMapping):
         self._write_op(self._put_nosync, d)
 
     def _put_nosync(self, d):
-        s = json_dumps(d)
-        self.store[self.key] = s.encode('ascii')
+        b = json_dumps(d)
+        self.store[self.key] = b
         if self.cache:
             self._cached_asdict = d
 

--- a/zarr/attrs.py
+++ b/zarr/attrs.py
@@ -113,8 +113,7 @@ class Attributes(MutableMapping):
         self._write_op(self._put_nosync, d)
 
     def _put_nosync(self, d):
-        b = json_dumps(d)
-        self.store[self.key] = b
+        self.store[self.key] = json_dumps(d)
         if self.cache:
             self._cached_asdict = d
 

--- a/zarr/attrs.py
+++ b/zarr/attrs.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
-import json
 from collections import MutableMapping
 
 
 from zarr.errors import PermissionError
 from zarr.meta import parse_metadata
+from zarr.util import json_dumps
 
 
 class Attributes(MutableMapping):
@@ -113,8 +113,7 @@ class Attributes(MutableMapping):
         self._write_op(self._put_nosync, d)
 
     def _put_nosync(self, d):
-        s = json.dumps(d, indent=4, sort_keys=True, ensure_ascii=True,
-                       separators=(',', ': '))
+        s = json_dumps(d)
         self.store[self.key] = s.encode('ascii')
         if self.cache:
             self._cached_asdict = d

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -1125,7 +1125,7 @@ def consolidate_metadata(store, metadata_key='.zmetadata'):
             for key in store if is_zarr_key(key)
         }
     }
-    store[metadata_key] = json_dumps(out).encode()
+    store[metadata_key] = json_dumps(out)
     return open_consolidated(store, metadata_key=metadata_key)
 
 

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
-import json
 import base64
 
 
@@ -9,15 +8,10 @@ import numpy as np
 
 from zarr.compat import PY2, Mapping
 from zarr.errors import MetadataError
-from zarr.util import ensure_text_type, json_dumps
+from zarr.util import json_dumps, json_loads
 
 
 ZARR_FORMAT = 2
-
-
-def json_loads(s):
-    """Read JSON in a consistent way."""
-    return json.loads(ensure_text_type(s))
 
 
 def parse_metadata(s):

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -9,16 +9,10 @@ import numpy as np
 
 from zarr.compat import PY2, Mapping
 from zarr.errors import MetadataError
-from zarr.util import ensure_text_type
+from zarr.util import ensure_text_type, json_dumps
 
 
 ZARR_FORMAT = 2
-
-
-def json_dumps(o):
-    """Write JSON in a consistent, human-readable way."""
-    return json.dumps(o, indent=4, sort_keys=True, ensure_ascii=True,
-                      separators=(',', ': '))
 
 
 def json_loads(s):

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -2,25 +2,17 @@
 from __future__ import absolute_import, print_function, division
 import json
 import base64
-import codecs
 
 
 import numpy as np
-from numcodecs.compat import ensure_contiguous_ndarray
 
 
-from zarr.compat import PY2, Mapping, text_type
+from zarr.compat import PY2, Mapping
 from zarr.errors import MetadataError
+from zarr.util import ensure_text_type
 
 
 ZARR_FORMAT = 2
-
-
-def ensure_text_type(s):
-    if not isinstance(s, text_type):
-        s = ensure_contiguous_ndarray(s)
-        s = codecs.decode(s, 'ascii')
-    return s
 
 
 def json_dumps(o):

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -75,8 +75,7 @@ def encode_array_metadata(meta):
         order=meta['order'],
         filters=meta['filters'],
     )
-    s = json_dumps(meta)
-    b = s.encode('ascii')
+    b = json_dumps(meta)
     return b
 
 
@@ -122,8 +121,7 @@ def encode_group_metadata(meta=None):
     meta = dict(
         zarr_format=ZARR_FORMAT,
     )
-    s = json_dumps(meta)
-    b = s.encode('ascii')
+    b = json_dumps(meta)
     return b
 
 

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -75,8 +75,7 @@ def encode_array_metadata(meta):
         order=meta['order'],
         filters=meta['filters'],
     )
-    b = json_dumps(meta)
-    return b
+    return json_dumps(meta)
 
 
 def encode_dtype(d):
@@ -121,8 +120,7 @@ def encode_group_metadata(meta=None):
     meta = dict(
         zarr_format=ZARR_FORMAT,
     )
-    b = json_dumps(meta)
-    return b
+    return json_dumps(meta)
 
 
 FLOAT_FILLS = {

--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -71,14 +71,14 @@ class N5Store(NestedDirectoryStore):
             key = key.replace(zarr_group_meta_key, n5_attrs_key)
             value = group_metadata_to_zarr(self._load_n5_attrs(key))
 
-            return json_dumps(value).encode('ascii')
+            return json_dumps(value)
 
         elif key.endswith(zarr_array_meta_key):
 
             key = key.replace(zarr_array_meta_key, n5_attrs_key)
             value = array_metadata_to_zarr(self._load_n5_attrs(key))
 
-            return json_dumps(value).encode('ascii')
+            return json_dumps(value)
 
         elif key.endswith(zarr_attrs_key):
 
@@ -88,7 +88,7 @@ class N5Store(NestedDirectoryStore):
             if len(value) == 0:
                 raise KeyError(key)
             else:
-                return json_dumps(value).encode('ascii')
+                return json_dumps(value)
 
         elif is_chunk_key(key):
 
@@ -105,7 +105,7 @@ class N5Store(NestedDirectoryStore):
             n5_attrs = self._load_n5_attrs(key)
             n5_attrs.update(**group_metadata_to_n5(json_loads(value)))
 
-            value = json_dumps(n5_attrs).encode('ascii')
+            value = json_dumps(n5_attrs)
 
         elif key.endswith(zarr_array_meta_key):
 
@@ -114,7 +114,7 @@ class N5Store(NestedDirectoryStore):
             n5_attrs = self._load_n5_attrs(key)
             n5_attrs.update(**array_metadata_to_n5(json_loads(value)))
 
-            value = json_dumps(n5_attrs).encode('ascii')
+            value = json_dumps(n5_attrs)
 
         elif key.endswith(zarr_attrs_key):
 
@@ -135,7 +135,7 @@ class N5Store(NestedDirectoryStore):
             # add new user attributes
             n5_attrs.update(**zarr_attrs)
 
-            value = json_dumps(n5_attrs).encode('ascii')
+            value = json_dumps(n5_attrs)
 
         elif is_chunk_key(key):
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -26,7 +26,6 @@ import atexit
 import errno
 import re
 import sys
-import json
 import multiprocessing
 from pickle import PicklingError
 from threading import Lock, RLock
@@ -34,7 +33,7 @@ import glob
 import warnings
 
 
-from zarr.util import (normalize_shape, normalize_chunks, normalize_order,
+from zarr.util import (json_loads, normalize_shape, normalize_chunks, normalize_order,
                        normalize_storage_path, buffer_size,
                        normalize_fill_value, nolock, normalize_dtype)
 from zarr.meta import encode_array_metadata, encode_group_metadata
@@ -2458,7 +2457,7 @@ class ConsolidatedMetadataStore(MutableMapping):
             d = store[metadata_key].decode()  # pragma: no cover
         else:  # pragma: no cover
             d = store[metadata_key]
-        meta = json.loads(d)
+        meta = json_loads(d)
 
         # check format of consolidated metadata
         consolidated_format = meta.get('zarr_consolidated_format', None)

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
 from textwrap import TextWrapper, dedent
+import codecs
 import numbers
 import uuid
 import inspect
@@ -9,7 +10,7 @@ import inspect
 from asciitree import BoxStyle, LeftAligned
 from asciitree.traversal import Traversal
 import numpy as np
-from numcodecs.compat import ensure_ndarray
+from numcodecs.compat import ensure_ndarray, ensure_contiguous_ndarray
 from numcodecs.registry import codec_registry
 
 
@@ -22,6 +23,13 @@ object_codecs = {
     binary_type.__name__: 'vlen-bytes',
     'array': 'vlen-array',
 }
+
+
+def ensure_text_type(s):
+    if not isinstance(s, text_type):
+        s = ensure_contiguous_ndarray(s)
+        s = codecs.decode(s, 'ascii')
+    return s
 
 
 def normalize_shape(shape):

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, print_function, division
 from textwrap import TextWrapper, dedent
 import codecs
+import json
 import numbers
 import uuid
 import inspect
@@ -30,6 +31,12 @@ def ensure_text_type(s):
         s = ensure_contiguous_ndarray(s)
         s = codecs.decode(s, 'ascii')
     return s
+
+
+def json_dumps(o):
+    """Write JSON in a consistent, human-readable way."""
+    return json.dumps(o, indent=4, sort_keys=True, ensure_ascii=True,
+                      separators=(',', ': '))
 
 
 def normalize_shape(shape):

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -39,6 +39,11 @@ def json_dumps(o):
                       separators=(',', ': '))
 
 
+def json_loads(s):
+    """Read JSON in a consistent way."""
+    return json.loads(ensure_text_type(s))
+
+
 def normalize_shape(shape):
     """Convenience function to normalize the `shape` argument."""
 

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -36,7 +36,7 @@ def ensure_text_type(s):
 def json_dumps(o):
     """Write JSON in a consistent, human-readable way."""
     return json.dumps(o, indent=4, sort_keys=True, ensure_ascii=True,
-                      separators=(',', ': '))
+                      separators=(',', ': ')).encode('ascii')
 
 
 def json_loads(s):


### PR DESCRIPTION
This refactors out the JSON utility functions created in PR ( https://github.com/zarr-developers/zarr/pull/429 ) and moves them from `zarr.meta` to `zarr.util`. It also employs them in other places where the `json` module was being used directly. Should make it easier to leverage the buffer protocol as part of the loading process. Finally includes the `encode` step within `json_dumps`, which eliminates the need for it to be done every time `json_dumps` is called, which simplifies the code a bit.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)