### PR TITLE
Fix `collections`'s `DeprecationWarning`s

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -12,6 +12,9 @@ Bug fixes
 * Coerce data to text for JSON parsing.
   By :user:`John Kirkham <jakirkham>`; :issue:`429`
 
+* Fix `collections`'s `DeprecationWarning`s.
+  By :user:`John Kirkham <jakirkham>`; :issue:`432`
+
 
 .. _release_2.3.1:
 

--- a/zarr/attrs.py
+++ b/zarr/attrs.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
 import json
-from collections import MutableMapping
 
 
+from zarr.compat import MutableMapping
 from zarr.errors import PermissionError
 from zarr.meta import parse_metadata
 

--- a/zarr/compat.py
+++ b/zarr/compat.py
@@ -20,7 +20,7 @@ if PY2:  # pragma: py3 no cover
     def OrderedDict_move_to_end(od, key):
         od[key] = od.pop(key)
 
-    from collections import Mapping, MutableMapping, OrderedDict
+    from collections import Mapping, MutableMapping
 
 
 else:  # pragma: py2 no cover
@@ -34,4 +34,4 @@ else:  # pragma: py2 no cover
     def OrderedDict_move_to_end(od, key):
         od.move_to_end(key)
 
-    from collections.abc import Mapping, MutableMapping, OrderedDict
+    from collections.abc import Mapping, MutableMapping

--- a/zarr/compat.py
+++ b/zarr/compat.py
@@ -20,7 +20,7 @@ if PY2:  # pragma: py3 no cover
     def OrderedDict_move_to_end(od, key):
         od[key] = od.pop(key)
 
-    from collections import Mapping
+    from collections import Mapping, MutableMapping, OrderedDict
 
 
 else:  # pragma: py2 no cover
@@ -34,4 +34,4 @@ else:  # pragma: py2 no cover
     def OrderedDict_move_to_end(od, key):
         od.move_to_end(key)
 
-    from collections.abc import Mapping
+    from collections.abc import Mapping, MutableMapping, OrderedDict

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Convenience functions for storing and loading data."""
 from __future__ import absolute_import, print_function, division
-from collections import Mapping
 import io
 import re
 import itertools
@@ -14,7 +13,7 @@ from zarr.hierarchy import open_group, group as _create_group, Group
 from zarr.storage import contains_array, contains_group
 from zarr.errors import err_path_not_found, CopyError
 from zarr.util import normalize_storage_path, TreeViewer, buffer_size
-from zarr.compat import PY2, text_type
+from zarr.compat import Mapping, PY2, text_type
 from zarr.meta import json_dumps, json_loads
 
 

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
-from collections import MutableMapping
 from itertools import islice
 
 import numpy as np
 
 
-from zarr.compat import PY2
+from zarr.compat import PY2, MutableMapping
 from zarr.attrs import Attributes
 from zarr.core import Array
 from zarr.storage import (contains_array, contains_group, init_group,

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -16,7 +16,7 @@ path) and a `getsize` method (return the size in bytes of a given value).
 
 """
 from __future__ import absolute_import, print_function, division
-from collections import MutableMapping, OrderedDict
+from collections import OrderedDict
 import os
 import operator
 import tempfile
@@ -38,7 +38,7 @@ from zarr.util import (normalize_shape, normalize_chunks, normalize_order,
                        normalize_storage_path, buffer_size,
                        normalize_fill_value, nolock, normalize_dtype)
 from zarr.meta import encode_array_metadata, encode_group_metadata
-from zarr.compat import PY2, OrderedDict_move_to_end
+from zarr.compat import PY2, MutableMapping, OrderedDict_move_to_end
 from numcodecs.registry import codec_registry
 from numcodecs.compat import ensure_bytes, ensure_contiguous_ndarray
 from zarr.errors import (err_contains_group, err_contains_array, err_bad_compressor,

--- a/zarr/tests/util.py
+++ b/zarr/tests/util.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
 import collections
+from zarr.compat import MutableMapping
 
 
-class CountingDict(collections.MutableMapping):
+class CountingDict(MutableMapping):
 
     def __init__(self):
         self.wrapped = dict()


### PR DESCRIPTION
When importing abstract base classes from `collections` (e.g. `MutableMapping`), a `DeprecationWarning` was issued stating that these would no longer be available in Python 3.8 and that we should use `collections.abc`s for this purpose instead. Here we handle importing `MutableMapping` in the `compat` module and have other modules import it from there. This allows us to have the right Python 2/3 behavior while avoiding these `DeprecationWarning`s.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
